### PR TITLE
stellar-etl: Set up file for account export command

### DIFF
--- a/cmd/accounts.go
+++ b/cmd/accounts.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// accountsCmd represents the accounts command
+var accountsCmd = &cobra.Command{
+	Use:   "accounts",
+	Short: "Exports the account data.",
+	Long:  `Exports historical account data within the specified ledger range to an output file.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		/*
+			Functionality planning:
+			1. Read in start and end ledger numbers
+			2. Provide ledger number to ingestion system and receive data
+			3. Convert data from ingestion into an array of Ledger structs with length equal to the limit
+			4. Write array to output file
+			TODO: Consider having a way to export directly to BigQuery using bigquery library
+		*/
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(accountsCmd)
+	/*
+		Needed flags:
+			TODO: determine if providing ledger sequence number or timestamp is preferable (possibly could do both)
+
+			start-time: the time for the beginning of the period to export; default to genesis ledger's creation time
+			end-time: the time for the end of the period to export (required)
+
+			start-ledger: the ledger sequence number for the beginning of the export period
+			end-ledger: the ledger sequence number for the end of the export range (required)
+
+			limit: maximum number of accounts to export; default to 1000
+			output-file: filename of the output file
+	*/
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What

A file for a command line function that exports accounts. The file contains comments describing the eventual functionality and flags for the command. Closes #8 

### Why

This is one of the commands that the ETL will use for exporting data. 

### Known limitations

The command is not functional, just described.
