### PR TITLE
cmd: Set up file for ledger export command 

### DIFF
--- a/cmd/ledgers.go
+++ b/cmd/ledgers.go
@@ -6,16 +6,16 @@ import (
 
 // ledgersCmd represents the ledgers command
 var ledgersCmd = &cobra.Command{
-	Use:   "ledgers",
+	Use:   "export_ledgers",
 	Short: "Exports the ledger data.",
-	Long:  `Exports ledger data within the specified ledger range to an output file. This each ledger also contains an extra numerical id, which is useful for constructing the history of the ledger.`,
+	Long:  `Exports ledger data within the specified range to an output file.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		/*
 			Functionality planning:
 			1. Read in start and end ledger numbers/timestamps
 				1b. If timestamps are received, convert them to ledger sequence numbers
 			2. Get each ledger in the range from the ingestion system
-			3. For each ledger received, make a corresponding Ledger struct in the output array
+			3. For each ledger received, make a corresponding Ledger struct in the output slice
 			4. Serialize array and output it to a file
 		*/
 	},
@@ -26,6 +26,7 @@ func init() {
 	/*
 		Needed flags:
 			TODO: determine if providing ledger sequence number or timestamp is preferable (possibly could do both)
+				If we do both, do not require both end-time and end-ledger
 
 			start-time: the time for the beginning of the period to export; default to genesis ledger's creation time
 			end-time: the time for the end of the period to export (required)
@@ -33,10 +34,10 @@ func init() {
 			start-ledger: the ledger sequence number for the beginning of the export period
 			end-ledger: the ledger sequence number for the end of the export range (required)
 
-			limit: maximum number of ledgers to export; default to 60 (5 ledgers per second over our 5 minute update period)
+			limit: maximum number of ledgers to export; default to 60 (1 ledger per 5 seconds over our 5 minute update period)
 			output-file: filename of the output file
 
 		Extra flags that may be useful:
-			serialize-method: the method for serialization of the output data (JSON, XRD, etc)
+			serialize-method: the method for serialization of the output data (JSON, XDR, etc)
 	*/
 }

--- a/cmd/ledgers.go
+++ b/cmd/ledgers.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// ledgersCmd represents the ledgers command
+var ledgersCmd = &cobra.Command{
+	Use:   "ledgers",
+	Short: "Exports the ledger data.",
+	Long:  `Exports ledger data within the specified ledger range to an output file. This each ledger also contains an extra numerical id, which is useful for constructing the history of the ledger.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		/*
+			Functionality planning:
+			1. Read in start and end ledger numbers/timestamps
+				1b. If timestamps are received, convert them to ledger sequence numbers
+			2. Get each ledger in the range from the ingestion system
+			3. For each ledger received, make a corresponding Ledger struct in the output array
+			4. Serialize array and output it to a file
+		*/
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(ledgersCmd)
+	/*
+		Needed flags:
+			TODO: determine if providing ledger sequence number or timestamp is preferable (possibly could do both)
+
+			start-time: the time for the beginning of the period to export; default to genesis ledger's creation time
+			end-time: the time for the end of the period to export (required)
+
+			start-ledger: the ledger sequence number for the beginning of the export period
+			end-ledger: the ledger sequence number for the end of the export range (required)
+
+			limit: maximum number of ledgers to export; default to 60 (5 ledgers per second over our 5 minute update period)
+			output-file: filename of the output file
+
+		Extra flags that may be useful:
+			serialize-method: the method for serialization of the output data (JSON, XRD, etc)
+	*/
+}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What

A file for a command line function that exports ledgers from the history archive. The file includes comments about the desired functionality and flags. Closes #10  

### Why

This is one of the commands that the ETL will use for exporting data. 

### Known limitations

The command is not functional, just described.
