### PR TITLE
cmd: Set up file for operations export command

### DIFF
--- a/cmd/operations.go
+++ b/cmd/operations.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// operationsCmd represents the operations command
+var operationsCmd = &cobra.Command{
+	Use:   "operations",
+	Short: "Exports the operations data over a specified range",
+	Long:  `Exports the operations data over a specified range. Operations are the components of transactions.  `,
+	Run: func(cmd *cobra.Command, args []string) {
+		/*
+			Functionality planning:
+			1. Read in start and end ledger numbers/timestamps
+				1b. If timestamps are received, convert them to ledger sequence numbers
+			2. Convert data from ingestion into an array of Operation structs with length equal to the limit
+				2b. Conversion will probably involve extracting the operations from the transactions that occurred over the time-frame
+			3. Serialize array and output it to a file
+		*/
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(operationsCmd)
+	/*
+		Needed flags:
+			TODO: determine if providing ledger sequence number or timestamp is preferable (possibly could do both)
+
+			start-time: the time for the beginning of the period to export; default to genesis ledger's creation time
+			end-time: the time for the end of the period to export (required)
+
+			start-ledger: the ledger sequence number for the beginning of the export period
+			end-ledger: the ledger sequence number for the end of the export range (required)
+
+			limit: maximum number of ledgers to export; default to 60 (5 ledgers per second over our 5 minute update period)
+			output-file: filename of the output file
+
+		Extra flags that may be useful:
+			serialize-method: the method for serialization of the output data (JSON, XRD, etc)
+	*/
+}

--- a/cmd/operations.go
+++ b/cmd/operations.go
@@ -6,15 +6,15 @@ import (
 
 // operationsCmd represents the operations command
 var operationsCmd = &cobra.Command{
-	Use:   "operations",
+	Use:   "export_operations",
 	Short: "Exports the operations data over a specified range",
-	Long:  `Exports the operations data over a specified range. Operations are the components of transactions.  `,
+	Long:  `Exports the operations data over a specified range. Each operation is an individual command that mutates the Stellar ledger.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		/*
 			Functionality planning:
 			1. Read in start and end ledger numbers/timestamps
 				1b. If timestamps are received, convert them to ledger sequence numbers
-			2. Convert data from ingestion into an array of Operation structs with length equal to the limit
+			2. Convert data from ingestion into a Go slice of Operation structs (length should at most be the limit)
 				2b. Conversion will probably involve extracting the operations from the transactions that occurred over the time-frame
 			3. Serialize array and output it to a file
 		*/
@@ -37,6 +37,6 @@ func init() {
 			output-file: filename of the output file
 
 		Extra flags that may be useful:
-			serialize-method: the method for serialization of the output data (JSON, XRD, etc)
+			serialize-method: the method for serialization of the output data (JSON, XDR, etc)
 	*/
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What

A file for a command line function that exports operations from the history archive. The comments in the file detail the desired functionality and flags. Closes #11 

### Why

This is one of the commands that the ETL will use for exporting data. 

### Known limitations

The command is not functional, just described.
