### PR TITLE
cmd: Set up file for trades export command

### DIFF
--- a/cmd/trades.go
+++ b/cmd/trades.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// tradesCmd represents the trades command
+var tradesCmd = &cobra.Command{
+	Use:   "export_trades",
+	Short: "Exports the trade data",
+	Long:  `Exports ledger data within the specified range to an output file`,
+	Run: func(cmd *cobra.Command, args []string) {
+		/*
+			Functionality planning:
+			1. Read in start and end ledger numbers/timestamps
+				1b. If timestamps are received, convert them to ledger sequence numbers
+			2. Receive data from ingestion and extract trades
+			3. Put trade information into a Go slice of Trade structs (length should at most be the limit)
+			4. Serialize slice and output it to a file
+		*/
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(tradesCmd)
+	/*
+		Needed flags:
+			TODO: determine if providing ledger sequence number or timestamp is preferable (possibly could do both)
+				*: If we do both, do not require both end-time and end-ledger; only need one or the other
+
+			start-time: the time for the beginning of the period to export; default to genesis ledger's creation time
+			end-time: the time for the end of the period to export (*required)
+
+			start-ledger: the ledger sequence number for the beginning of the export period
+			end-ledger: the ledger sequence number for the end of the export range (*required)
+
+			limit: maximum number of trades to export
+				TODO: measure a good default value that ensures all trades within a 5 minute period will be exported with a single call
+
+			output-file: filename of the output file
+
+		Extra flags that may be useful:
+			serialize-method: the method for serialization of the output data (JSON, XDR, etc)
+	*/
+}

--- a/cmd/trades.go
+++ b/cmd/trades.go
@@ -8,7 +8,7 @@ import (
 var tradesCmd = &cobra.Command{
 	Use:   "export_trades",
 	Short: "Exports the trade data",
-	Long:  `Exports ledger data within the specified range to an output file`,
+	Long:  `Exports trade data within the specified range to an output file`,
 	Run: func(cmd *cobra.Command, args []string) {
 		/*
 			Functionality planning:


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What

A file for a command line function that exports trades from the history archive. The comments in the file detail the desired functionality and flags. Closes #12 

### Why

This is one of the commands that the ETL will use for exporting data. 

### Known limitations

The command is not functional, just described.
