### PR TITLE
cmd: minor fixes to earlier commands

### DIFF
--- a/cmd/accounts.go
+++ b/cmd/accounts.go
@@ -6,16 +6,16 @@ import (
 
 // accountsCmd represents the accounts command
 var accountsCmd = &cobra.Command{
-	Use:   "accounts",
+	Use:   "export_accounts",
 	Short: "Exports the account data.",
-	Long:  `Exports historical account data within the specified ledger range to an output file.`,
+	Long:  `Exports historical account data within the specified range to an output file.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		/*
 			Functionality planning:
 			1. Read in start and end ledger numbers
 			2. Provide ledger number to ingestion system and receive data
-			3. Convert data from ingestion into an array of Ledger structs with length equal to the limit
-			4. Write array to output file
+			3. Convert data from ingestion into an slice of Account structs (length should at most be the limit)
+			4. Write slice to output file
 			TODO: Consider having a way to export directly to BigQuery using bigquery library
 		*/
 	},
@@ -33,7 +33,9 @@ func init() {
 			start-ledger: the ledger sequence number for the beginning of the export period
 			end-ledger: the ledger sequence number for the end of the export range (required)
 
-			limit: maximum number of accounts to export; default to 1000
+			limit: maximum number of accounts to export;
+				TODO: measure a good default value that ensures all accounts within a 5 minute period will be exported with a single call
+
 			output-file: filename of the output file
 	*/
 }

--- a/cmd/accounts.go
+++ b/cmd/accounts.go
@@ -15,8 +15,7 @@ var accountsCmd = &cobra.Command{
 			1. Read in start and end ledger numbers
 			2. Provide ledger number to ingestion system and receive data
 			3. Convert data from ingestion into an slice of Account structs (length should at most be the limit)
-			4. Write slice to output file
-			TODO: Consider having a way to export directly to BigQuery using bigquery library
+			4. Serialize slice and write it to output file
 		*/
 	},
 }
@@ -37,5 +36,8 @@ func init() {
 				TODO: measure a good default value that ensures all accounts within a 5 minute period will be exported with a single call
 
 			output-file: filename of the output file
+
+		Extra flags that may be useful:
+			serialize-method: the method for serialization of the output data (JSON, XDR, etc)
 	*/
 }

--- a/cmd/ledgers.go
+++ b/cmd/ledgers.go
@@ -15,8 +15,8 @@ var ledgersCmd = &cobra.Command{
 			1. Read in start and end ledger numbers/timestamps
 				1b. If timestamps are received, convert them to ledger sequence numbers
 			2. Get each ledger in the range from the ingestion system
-			3. For each ledger received, make a corresponding Ledger struct in the output slice
-			4. Serialize array and output it to a file
+			3. For each ledger received, make a corresponding Ledger struct in the output slice (slice has a max length of limit)
+			4. Serialize slice and output it to a file
 		*/
 	},
 }

--- a/cmd/operations.go
+++ b/cmd/operations.go
@@ -26,14 +26,15 @@ func init() {
 	/*
 		Needed flags:
 			TODO: determine if providing ledger sequence number or timestamp is preferable (possibly could do both)
+				*: If we do both, do not require both end-time and end-ledger; only need one or the other
 
 			start-time: the time for the beginning of the period to export; default to genesis ledger's creation time
-			end-time: the time for the end of the period to export (required)
+			end-time: the time for the end of the period to export (*required)
 
 			start-ledger: the ledger sequence number for the beginning of the export period
-			end-ledger: the ledger sequence number for the end of the export range (required)
+			end-ledger: the ledger sequence number for the end of the export range (*required)
 
-			limit: maximum number of ledgers to export;
+			limit: maximum number of operations to export
 				Default to 300,000 as there are 60 ledgers in a 5 minute period, each with 50 transactions, and each transaction can have up to 100 operations
 
 			output-file: filename of the output file

--- a/cmd/operations.go
+++ b/cmd/operations.go
@@ -16,7 +16,7 @@ var operationsCmd = &cobra.Command{
 				1b. If timestamps are received, convert them to ledger sequence numbers
 			2. Convert data from ingestion into a Go slice of Operation structs (length should at most be the limit)
 				2b. Conversion will probably involve extracting the operations from the transactions that occurred over the time-frame
-			3. Serialize array and output it to a file
+			3. Serialize slice and output it to a file
 		*/
 	},
 }
@@ -33,7 +33,9 @@ func init() {
 			start-ledger: the ledger sequence number for the beginning of the export period
 			end-ledger: the ledger sequence number for the end of the export range (required)
 
-			limit: maximum number of ledgers to export; default to 60 (5 ledgers per second over our 5 minute update period)
+			limit: maximum number of ledgers to export;
+				Default to 300,000 as there are 60 ledgers in a 5 minute period, each with 50 transactions, and each transaction can have up to 100 operations
+
 			output-file: filename of the output file
 
 		Extra flags that may be useful:


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What

There are minor fixes in the wording of earlier commands, specifically the accounts, operations, and ledgers export commands. Fixes include improving the wording of command descriptions, ensuring comments contain as much information as possible, and ensuring default flag values make sense. 

### Why

These fixes were made in later PRs, but some corrections and additional information was missing from these earlier commands. Now, everything should be formatted in a similar manner and no commands should be lacking information. This will make development easier in the future.

### Known limitations

