### PR TITLE
internal: added transform for operations

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -258,6 +258,7 @@ github.com/stellar/go v0.0.0-20200713182524-95680941e5c1/go.mod h1:8HtdR7lVqG6yR
 github.com/stellar/go v0.0.0-20200715144943-c92667eaba34 h1:CVr9JYO2JWIMGFYswm9eQM3cr+xYcxkNwfCtMMoREPk=
 github.com/stellar/go v0.0.0-20200716132855-ded108912a76 h1:Xm1Q8GVki11Wp93f/uSrT/hMM/83ADGddZ/OHW+GFZQ=
 github.com/stellar/go v0.0.0-20200717143051-d6b3d1237d72 h1:NgW+JKioanAaQ2NFHMKllKuWLjK1BrHlH3ROQ/5LA04=
+github.com/stellar/go v0.0.0-20200720192608-6c5a3270659a h1:3l+ph33c7P8pU36A8CxWVlWg4iXCmvo26i+zP+rtVw0=
 github.com/stellar/go-xdr v0.0.0-20180917104419-0bc96f33a18e h1:n/hfey8pO+RYMoGXyvyzuw5pdO8IFDoyAL/g5OiCesY=
 github.com/stellar/go-xdr v0.0.0-20180917104419-0bc96f33a18e/go.mod h1:gpOLVzy6TVYTQ3LvHSN9RJC700FkhFCpSE82u37aNRM=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,7 @@ github.com/stellar/go v0.0.0-20200713182524-95680941e5c1 h1:TLRHifcmPq8LOWqtLRIB
 github.com/stellar/go v0.0.0-20200713182524-95680941e5c1/go.mod h1:8HtdR7lVqG6yRCbn4p820iOmMmcdhVhV+kxS/ZhmcKk=
 github.com/stellar/go v0.0.0-20200715144943-c92667eaba34 h1:CVr9JYO2JWIMGFYswm9eQM3cr+xYcxkNwfCtMMoREPk=
 github.com/stellar/go v0.0.0-20200716132855-ded108912a76 h1:Xm1Q8GVki11Wp93f/uSrT/hMM/83ADGddZ/OHW+GFZQ=
+github.com/stellar/go v0.0.0-20200717143051-d6b3d1237d72 h1:NgW+JKioanAaQ2NFHMKllKuWLjK1BrHlH3ROQ/5LA04=
 github.com/stellar/go-xdr v0.0.0-20180917104419-0bc96f33a18e h1:n/hfey8pO+RYMoGXyvyzuw5pdO8IFDoyAL/g5OiCesY=
 github.com/stellar/go-xdr v0.0.0-20180917104419-0bc96f33a18e/go.mod h1:gpOLVzy6TVYTQ3LvHSN9RJC700FkhFCpSE82u37aNRM=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=

--- a/internal/transform/operation.go
+++ b/internal/transform/operation.go
@@ -1,0 +1,350 @@
+package transform
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+
+	"github.com/stellar/go/amount"
+	ingestio "github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/xdr"
+	"github.com/stellar/stellar-etl/internal/utils"
+)
+
+//TransformOperation converts an operation from the history archive ingestion system into a form suitable for BigQuery
+func TransformOperation(operation xdr.Operation, operationIndex int32, transaction ingestio.LedgerTransaction) (OperationOutput, error) {
+	outputSourceAccount, err := utils.GetAccountAddressFromMuxedAccount(getOperationSourceAccount(operation, transaction))
+	if err != nil {
+		return OperationOutput{}, err
+	}
+
+	outputOperationType := int32(operation.Body.Type)
+	if outputOperationType < 0 {
+		return OperationOutput{}, fmt.Errorf("The operation type (%d) is negative for  operation %d", outputOperationType, operationIndex)
+	}
+
+	outputDetails, err := extractOperationDetails(operation, transaction, operationIndex)
+	if err != nil {
+		return OperationOutput{}, err
+	}
+
+	transformedOperation := OperationOutput{
+		SourceAccount:    outputSourceAccount,
+		Type:             outputOperationType,
+		ApplicationOrder: operationIndex,
+		OperationDetails: outputDetails,
+	}
+
+	return transformedOperation, nil
+}
+
+func getOperationSourceAccount(operation xdr.Operation, transaction ingestio.LedgerTransaction) xdr.MuxedAccount {
+	sourceAccount := operation.SourceAccount
+	if sourceAccount != nil {
+		return *sourceAccount
+	}
+
+	return transaction.Envelope.SourceAccount()
+}
+
+func addAssetDetailsToOperationDetails(operationDetails *Details, asset xdr.Asset, prefix string) error {
+	var assetType, issuer, code string
+	err := asset.Extract(&assetType, &issuer, &code)
+	if err != nil {
+		return err
+	}
+
+	switch prefix {
+	case "buying":
+		operationDetails.BuyingAssetType = assetType
+		if asset.Type != xdr.AssetTypeAssetTypeNative {
+			operationDetails.BuyingAssetIssuer = issuer
+			operationDetails.BuyingAssetCode = code
+		}
+
+	case "selling":
+		operationDetails.SellingAssetType = assetType
+		if asset.Type != xdr.AssetTypeAssetTypeNative {
+			operationDetails.SellingAssetIssuer = issuer
+			operationDetails.SellingAssetCode = code
+		}
+
+	case "source":
+		operationDetails.SourceAssetType = assetType
+		if asset.Type != xdr.AssetTypeAssetTypeNative {
+			operationDetails.SourceAssetIssuer = issuer
+			operationDetails.SourceAssetCode = code
+		}
+
+	default:
+		operationDetails.AssetType = assetType
+		if asset.Type != xdr.AssetTypeAssetTypeNative {
+			operationDetails.AssetIssuer = issuer
+			operationDetails.AssetCode = code
+		}
+
+	}
+	return nil
+}
+func addOperationFlagToOperationDetails(operationDetails Details, flag int32, prefix string) {
+	var intFlags []int32
+	var stringFlags []string
+
+	if (flag & int32(xdr.AccountFlagsAuthRequiredFlag)) > 0 {
+		intFlags = append(intFlags, int32(xdr.AccountFlagsAuthRequiredFlag))
+		stringFlags = append(stringFlags, "auth_required")
+	}
+
+	if (flag & int32(xdr.AccountFlagsAuthRevocableFlag)) > 0 {
+		intFlags = append(intFlags, int32(xdr.AccountFlagsAuthRevocableFlag))
+		stringFlags = append(stringFlags, "auth_revocable")
+	}
+
+	if (flag & int32(xdr.AccountFlagsAuthImmutableFlag)) > 0 {
+		intFlags = append(intFlags, int32(xdr.AccountFlagsAuthImmutableFlag))
+		stringFlags = append(stringFlags, "auth_immutable")
+	}
+
+	switch prefix {
+	case "set":
+		operationDetails.SetFlags = intFlags
+		operationDetails.SetFlagsString = stringFlags
+
+	case "clear":
+		operationDetails.ClearFlags = intFlags
+		operationDetails.ClearFlagsString = stringFlags
+	}
+}
+
+func extractOperationDetails(operation xdr.Operation, transaction ingestio.LedgerTransaction, operationIndex int32) (Details, error) {
+	outputDetails := Details{}
+	sourceAccount := getOperationSourceAccount(operation, transaction)
+	sourceAccountAddress, _ := utils.GetAccountAddressFromMuxedAccount(sourceAccount)
+	operationType := operation.Body.Type
+	allOperationResults, ok := transaction.Result.OperationResults()
+	if !ok {
+		return Details{}, fmt.Errorf("Could not access any results for this transaction")
+	}
+
+	currentOperationResult := allOperationResults[operationIndex]
+	switch operationType {
+	case xdr.OperationTypeCreateAccount:
+		op := operation.Body.MustCreateAccountOp()
+		outputDetails.Funder = sourceAccountAddress
+		outputDetails.Account = op.Destination.Address()
+		outputDetails.StartingBalance = float64(op.StartingBalance)
+
+	case xdr.OperationTypePayment:
+		op := operation.Body.MustPaymentOp()
+		outputDetails.From = sourceAccountAddress
+		toAccountAddress, err := utils.GetAccountAddressFromMuxedAccount(op.Destination)
+		if err != nil {
+			return Details{}, err
+		}
+
+		outputDetails.To = toAccountAddress
+		outputDetails.Amount = float64(op.Amount)
+		err = addAssetDetailsToOperationDetails(&outputDetails, op.Asset, "")
+		if err != nil {
+			return Details{}, err
+		}
+
+	case xdr.OperationTypePathPaymentStrictReceive:
+		op := operation.Body.MustPathPaymentStrictReceiveOp()
+		outputDetails.From = sourceAccountAddress
+		toAccountAddress, err := utils.GetAccountAddressFromMuxedAccount(op.Destination)
+		if err != nil {
+			return Details{}, err
+		}
+		outputDetails.To = toAccountAddress
+
+		outputDetails.Amount = float64(op.DestAmount)
+		outputDetails.SourceAmount = float64(0)
+		outputDetails.SourceMax = float64(op.SendMax)
+		addAssetDetailsToOperationDetails(&outputDetails, op.DestAsset, "")
+		addAssetDetailsToOperationDetails(&outputDetails, op.SendAsset, "source")
+
+		if transaction.Result.Successful() {
+			result := currentOperationResult.MustTr().MustPathPaymentStrictReceiveResult()
+			outputDetails.SourceAmount = float64(result.SendAmount())
+		}
+
+		var path = []AssetOutput{}
+		for _, pathAsset := range op.Path {
+			var assetType, issuer, code string
+			err := pathAsset.Extract(&assetType, &issuer, &code)
+			if err != nil {
+				return Details{}, err
+			}
+			path = append(path, AssetOutput{
+				AssetType:   assetType,
+				AssetIssuer: issuer,
+				AssetCode:   code,
+			})
+		}
+		outputDetails.Path = path
+
+	case xdr.OperationTypePathPaymentStrictSend:
+		op := operation.Body.MustPathPaymentStrictSendOp()
+		outputDetails.From = sourceAccountAddress
+		toAccountAddress, err := utils.GetAccountAddressFromMuxedAccount(op.Destination)
+		if err != nil {
+			return Details{}, err
+		}
+		outputDetails.To = toAccountAddress
+
+		outputDetails.Amount = float64(0)
+		outputDetails.SourceAmount = float64(op.SendAmount)
+		outputDetails.DestinationMin = amount.String(op.DestMin)
+		addAssetDetailsToOperationDetails(&outputDetails, op.DestAsset, "")
+		addAssetDetailsToOperationDetails(&outputDetails, op.SendAsset, "source")
+
+		if transaction.Result.Successful() {
+			result := currentOperationResult.MustTr().MustPathPaymentStrictSendResult()
+			outputDetails.Amount = float64(result.DestAmount())
+		}
+
+		var path = []AssetOutput{}
+		for _, pathAsset := range op.Path {
+			var assetType, issuer, code string
+			err := pathAsset.Extract(&assetType, &issuer, &code)
+			if err != nil {
+				return Details{}, err
+			}
+
+			path = append(path, AssetOutput{
+				AssetType:   assetType,
+				AssetIssuer: issuer,
+				AssetCode:   code,
+			})
+		}
+		outputDetails.Path = path
+
+	case xdr.OperationTypeManageBuyOffer:
+		op := operation.Body.MustManageBuyOfferOp()
+		outputDetails.OfferID = int64(op.OfferId)
+		outputDetails.Amount = float64(op.BuyAmount)
+		parsedPrice, err := strconv.ParseFloat(op.Price.String(), 64)
+		if err != nil {
+			return Details{}, err
+		}
+
+		outputDetails.Price = parsedPrice
+		outputDetails.PriceR = Price{
+			Numerator:   int32(op.Price.N),
+			Denominator: int32(op.Price.D),
+		}
+		addAssetDetailsToOperationDetails(&outputDetails, op.Buying, "buying")
+		addAssetDetailsToOperationDetails(&outputDetails, op.Selling, "selling")
+
+	case xdr.OperationTypeManageSellOffer:
+		op := operation.Body.MustManageSellOfferOp()
+		outputDetails.OfferID = int64(op.OfferId)
+		outputDetails.Amount = float64(op.Amount)
+		parsedPrice, err := strconv.ParseFloat(op.Price.String(), 64)
+		if err != nil {
+			return Details{}, err
+		}
+
+		outputDetails.Price = parsedPrice
+		outputDetails.PriceR = Price{
+			Numerator:   int32(op.Price.N),
+			Denominator: int32(op.Price.D),
+		}
+		addAssetDetailsToOperationDetails(&outputDetails, op.Buying, "buying")
+		addAssetDetailsToOperationDetails(&outputDetails, op.Selling, "selling")
+	case xdr.OperationTypeCreatePassiveSellOffer:
+		op := operation.Body.MustCreatePassiveSellOfferOp()
+		outputDetails.Amount = float64(op.Amount)
+		parsedPrice, err := strconv.ParseFloat(op.Price.String(), 64)
+		if err != nil {
+			return Details{}, err
+		}
+
+		outputDetails.Price = parsedPrice
+		outputDetails.PriceR = Price{
+			Numerator:   int32(op.Price.N),
+			Denominator: int32(op.Price.D),
+		}
+		addAssetDetailsToOperationDetails(&outputDetails, op.Buying, "buying")
+		addAssetDetailsToOperationDetails(&outputDetails, op.Selling, "selling")
+
+	case xdr.OperationTypeSetOptions:
+		op := operation.Body.MustSetOptionsOp()
+
+		if op.InflationDest != nil {
+			outputDetails.InflationDest = op.InflationDest.Address()
+		}
+
+		if op.SetFlags != nil && *op.SetFlags > 0 {
+			addOperationFlagToOperationDetails(outputDetails, int32(*op.SetFlags), "set")
+		}
+
+		if op.ClearFlags != nil && *op.ClearFlags > 0 {
+			addOperationFlagToOperationDetails(outputDetails, int32(*op.ClearFlags), "clear")
+		}
+
+		if op.MasterWeight != nil {
+			outputDetails.MasterKeyWeight = int32(*op.MasterWeight)
+		}
+
+		if op.LowThreshold != nil {
+			outputDetails.LowThreshold = int32(*op.LowThreshold)
+		}
+
+		if op.MedThreshold != nil {
+			outputDetails.MedThreshold = int32(*op.MedThreshold)
+		}
+
+		if op.HighThreshold != nil {
+			outputDetails.HighThreshold = int32(*op.HighThreshold)
+		}
+
+		if op.HomeDomain != nil {
+			outputDetails.HomeDomain = string(*op.HomeDomain)
+		}
+
+		if op.Signer != nil {
+			outputDetails.SignerKey = op.Signer.Key.Address()
+			outputDetails.SignerWeight = int32(op.Signer.Weight)
+		}
+
+	case xdr.OperationTypeChangeTrust:
+		op := operation.Body.MustChangeTrustOp()
+		addAssetDetailsToOperationDetails(&outputDetails, op.Line, "")
+		outputDetails.Trustor = sourceAccountAddress
+		outputDetails.Trustee = outputDetails.AssetIssuer
+		outputDetails.Limit = float64(op.Limit)
+
+	case xdr.OperationTypeAllowTrust:
+		op := operation.Body.MustAllowTrustOp()
+		addAssetDetailsToOperationDetails(&outputDetails, op.Asset.ToAsset(sourceAccount.ToAccountId()), "")
+		outputDetails.Trustee = sourceAccountAddress
+		outputDetails.Trustor = op.Trustor.Address()
+		outputDetails.Authorize = xdr.TrustLineFlags(op.Authorize).IsAuthorized()
+
+	case xdr.OperationTypeAccountMerge:
+		aid := operation.Body.MustDestination().ToAccountId()
+		outputDetails.Account = sourceAccountAddress
+		outputDetails.Into = aid.Address()
+
+	case xdr.OperationTypeInflation:
+		// inflation is deprecated
+	case xdr.OperationTypeManageData:
+		op := operation.Body.MustManageDataOp()
+		outputDetails.Name = string(op.DataName)
+		if op.DataValue != nil {
+			outputDetails.Value = base64.StdEncoding.EncodeToString(*op.DataValue)
+		} else {
+			outputDetails.Value = ""
+		}
+
+	case xdr.OperationTypeBumpSequence:
+		op := operation.Body.MustBumpSequenceOp()
+		outputDetails.BumpTo = fmt.Sprintf("%d", op.BumpTo)
+
+	default:
+		return Details{}, fmt.Errorf("Unknown operation type: %s", operation.Body.Type.String())
+	}
+	return outputDetails, nil
+}

--- a/internal/transform/operation.go
+++ b/internal/transform/operation.go
@@ -31,7 +31,7 @@ func TransformOperation(operation xdr.Operation, operationIndex int32, transacti
 	transformedOperation := OperationOutput{
 		SourceAccount:    outputSourceAccount,
 		Type:             outputOperationType,
-		ApplicationOrder: operationIndex,
+		ApplicationOrder: operationIndex + 1,
 		OperationDetails: outputDetails,
 	}
 
@@ -253,6 +253,7 @@ func extractOperationDetails(operation xdr.Operation, transaction ingestio.Ledge
 		}
 		addAssetDetailsToOperationDetails(&outputDetails, op.Buying, "buying")
 		addAssetDetailsToOperationDetails(&outputDetails, op.Selling, "selling")
+		
 	case xdr.OperationTypeCreatePassiveSellOffer:
 		op := operation.Body.MustCreatePassiveSellOfferOp()
 		outputDetails.Amount = float64(op.Amount)

--- a/internal/transform/operation_test.go
+++ b/internal/transform/operation_test.go
@@ -1,0 +1,212 @@
+package transform
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	ingestio "github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/exp/ingest/ledgerbackend"
+	"github.com/stellar/go/network"
+	"github.com/stellar/go/xdr"
+	"github.com/stellar/stellar-etl/internal/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestArchiveBackend() *ledgerbackend.HistoryArchiveBackend {
+	archiveStellarURL := "http://history.stellar.org/prd/core-live/core_live_001"
+	backend, err := ledgerbackend.NewHistoryArchiveBackendFromURL(archiveStellarURL)
+	utils.PanicOnError(err)
+	return backend
+}
+func TestLive(t *testing.T) {
+	sequenceNumber := uint32(22490180) //21585418 for account creation; 21585418 for payment; 22490180 for path receive
+	backend := createTestArchiveBackend()
+	txReader, err := ingestio.NewLedgerTransactionReader(backend, network.PublicNetworkPassphrase, sequenceNumber)
+	utils.PanicOnError(err)
+	for {
+		tx, err := txReader.Read()
+		if err == io.EOF {
+			break
+		}
+		utils.PanicOnError(err)
+		envelope := tx.Envelope
+		for index, op := range envelope.Operations() {
+			if op.Body.Type == xdr.OperationTypePathPaymentStrictReceive && tx.Result.Successful() {
+				fmt.Println(op)
+			}
+			convertedOp, err := TransformOperation(op, int32(index), tx)
+			utils.PanicOnError(err)
+			fmt.Println(convertedOp.Type)
+		}
+	}
+}
+
+func TestTransformOperation(t *testing.T) {
+	type operationInput struct {
+		operation   xdr.Operation
+		index       int32
+		transaction ingestio.LedgerTransaction
+	}
+	type transformTest struct {
+		input      operationInput
+		wantOutput OperationOutput
+		wantErr    error
+	}
+	genericInput := operationInput{genericOperation, 1, genericLedgerTransaction}
+
+	negativeOpTypeInput := genericInput
+	negativeOpTypeEnvelope := genericEnvelope
+	negativeOpTypeEnvelope.Tx.Operations[0].Body.Type = xdr.OperationType(-1)
+	negativeOpTypeInput.operation.Body.Type = xdr.OperationType(-1)
+	negativeOpTypeInput.transaction.Envelope.V1 = &negativeOpTypeEnvelope
+
+	unknownOpTypeInput := genericInput
+	unknownOpTypeEnvelope := genericEnvelope
+	unknownOpTypeEnvelope.Tx.Operations[0].Body.Type = xdr.OperationType(20)
+	unknownOpTypeInput.operation.Body.Type = xdr.OperationType(20)
+	unknownOpTypeInput.transaction.Envelope.V1 = &unknownOpTypeEnvelope
+
+	tests := []transformTest{
+		{
+			negativeOpTypeInput,
+			OperationOutput{},
+			fmt.Errorf("The operation type (-1) is negative for  operation 1"),
+		},
+		{
+			unknownOpTypeInput,
+			OperationOutput{},
+			fmt.Errorf("Unknown operation type: "),
+		},
+	}
+	hardCodedInputTransaction, err := prepareHardcodedOperationTestInput()
+	assert.NoError(t, err)
+	hardCodedOutputArray := prepareHardcodedOperationTestOutputs()
+
+	for i, op := range hardCodedInputTransaction.Envelope.Operations() {
+		tests = append(tests, transformTest{
+			input:      operationInput{op, int32(i), hardCodedInputTransaction},
+			wantOutput: hardCodedOutputArray[i],
+			wantErr:    nil,
+		})
+	}
+
+	for _, test := range tests {
+		actualOutput, actualError := TransformOperation(test.input.operation, test.input.index, test.input.transaction)
+		assert.Equal(t, test.wantErr, actualError)
+		assert.Equal(t, test.wantOutput, actualOutput)
+	}
+}
+
+//creates a single transaction that contains one of every operation type
+func prepareHardcodedOperationTestInput() (inputTransaction ingestio.LedgerTransaction, err error) {
+	inputTransaction = genericLedgerTransaction
+	inputEnvelope := genericEnvelope
+	hardCodedSourceAccount, err := xdr.NewMuxedAccount(xdr.CryptoKeyTypeKeyTypeEd25519, xdr.Uint256([32]byte{0x67, 0xcc, 0x0, 0x86, 0x4c, 0x3b, 0x89, 0x16, 0x8c, 0x6a, 0xaf, 0xe0, 0xbc, 0x34, 0x70, 0x9e, 0xd0, 0x21, 0xc5, 0x5, 0x72, 0xe2, 0xf9, 0x88, 0x61, 0x34, 0x22, 0x8, 0x2c, 0x22, 0x29, 0x72}))
+	if err != nil {
+		return
+	}
+	hardCodedDestAccount, err := xdr.NewMuxedAccount(xdr.CryptoKeyTypeKeyTypeEd25519, xdr.Uint256([32]byte{0x6b, 0x58, 0xdd, 0x6c, 0x68, 0x93, 0xb, 0x6d, 0x3, 0x1d, 0xc5, 0xbb, 0xfa, 0xe2, 0x3e, 0xfa, 0x1e, 0xc3, 0xf0, 0xbb, 0x58, 0xc2, 0xbc, 0x8d, 0x93, 0x8d, 0x47, 0xc1, 0xdf, 0xb3, 0xbe, 0x73}))
+	if err != nil {
+		return
+	}
+	inputEnvelope.Tx.SourceAccount = hardCodedSourceAccount
+	hardCodedAsset := xdr.Asset{
+		Type: xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AlphaNum4: &xdr.AssetAlphaNum4{
+			AssetCode: xdr.AssetCode4([4]byte{}),
+			Issuer:    hardCodedDestAccount.ToAccountId(),
+		},
+	}
+	hardCodedNativeAsset := xdr.MustNewNativeAsset()
+	inputOperations := []xdr.Operation{
+		xdr.Operation{
+			SourceAccount: nil,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypeCreateAccount,
+				CreateAccountOp: &xdr.CreateAccountOp{
+					StartingBalance: 25000000,
+					Destination:     hardCodedDestAccount.ToAccountId(),
+				},
+			},
+		},
+		xdr.Operation{
+			SourceAccount: nil,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypePayment,
+				PaymentOp: &xdr.PaymentOp{
+					Destination: hardCodedDestAccount,
+					Asset:       hardCodedAsset,
+					Amount:      350000000,
+				},
+			},
+		},
+		xdr.Operation{
+			SourceAccount: nil,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypePayment,
+				PaymentOp: &xdr.PaymentOp{
+					Destination: hardCodedDestAccount,
+					Asset:       hardCodedNativeAsset,
+					Amount:      350000000,
+				},
+			},
+		},
+		xdr.Operation{
+			SourceAccount: &hardCodedSourceAccount,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypePathPaymentStrictReceive,
+			},
+		},
+		xdr.Operation{
+			SourceAccount: &hardCodedSourceAccount,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypeManageSellOffer,
+			},
+		},
+		xdr.Operation{
+			SourceAccount: &hardCodedSourceAccount,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypeCreatePassiveSellOffer,
+			},
+		},
+	}
+	inputEnvelope.Tx.Operations = inputOperations
+	inputTransaction.Envelope.V1 = &inputEnvelope
+	return
+}
+
+func prepareHardcodedOperationTestOutputs() (transformedOperations []OperationOutput) {
+	transformedOperations = []OperationOutput{
+		OperationOutput{
+			SourceAccount: "GBT4YAEGJQ5YSFUMNKX6BPBUOCPNAIOFAVZOF6MIME2CECBMEIUXFZZN",
+			Type:          0,
+			OperationDetails: Details{
+				Account:         "GBVVRXLMNCJQW3IDDXC3X6XCH35B5Q7QXNMMFPENSOGUPQO7WO7HGZPA",
+				Funder:          "GBT4YAEGJQ5YSFUMNKX6BPBUOCPNAIOFAVZOF6MIME2CECBMEIUXFZZN",
+				StartingBalance: 25000000,
+			},
+		},
+		OperationOutput{
+			Type:             1,
+			OperationDetails: Details{},
+		},
+		OperationOutput{
+			Type:             1,
+			OperationDetails: Details{},
+		},
+		OperationOutput{
+			Type:             2,
+			OperationDetails: Details{},
+		},
+		OperationOutput{
+			Type:             3,
+			OperationDetails: Details{},
+		},
+		OperationOutput{
+			Type:             4,
+			OperationDetails: Details{},
+		},
+	}
+	return
+}

--- a/internal/transform/operation_test.go
+++ b/internal/transform/operation_test.go
@@ -1,6 +1,7 @@
 package transform
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io"
 	"testing"
@@ -20,7 +21,12 @@ func createTestArchiveBackend() *ledgerbackend.HistoryArchiveBackend {
 	return backend
 }
 func TestLive(t *testing.T) {
-	sequenceNumber := uint32(22490180) //21585418 for account creation; 21585418 for payment; 22490180 for path receive
+	/*
+		21585418 for account creation; 21585418 for payment; 22490180 for path receive
+		22490168 for manage sell (2nd one); 22490175 for create passive; 29353599 for set options
+		22490190 for change trust; 30659243 for manage buy (4th one); 30540921 for path send
+	*/
+	sequenceNumber := uint32(30540921)
 	backend := createTestArchiveBackend()
 	txReader, err := ingestio.NewLedgerTransactionReader(backend, network.PublicNetworkPassphrase, sequenceNumber)
 	utils.PanicOnError(err)
@@ -32,7 +38,7 @@ func TestLive(t *testing.T) {
 		utils.PanicOnError(err)
 		envelope := tx.Envelope
 		for index, op := range envelope.Operations() {
-			if op.Body.Type == xdr.OperationTypePathPaymentStrictReceive && tx.Result.Successful() {
+			if op.Body.Type == xdr.OperationTypePathPaymentStrictSend && tx.Result.Successful() {
 				fmt.Println(op)
 			}
 			convertedOp, err := TransformOperation(op, int32(index), tx)
@@ -106,19 +112,47 @@ func prepareHardcodedOperationTestInput() (inputTransaction ingestio.LedgerTrans
 	if err != nil {
 		return
 	}
+
 	hardCodedDestAccount, err := xdr.NewMuxedAccount(xdr.CryptoKeyTypeKeyTypeEd25519, xdr.Uint256([32]byte{0x6b, 0x58, 0xdd, 0x6c, 0x68, 0x93, 0xb, 0x6d, 0x3, 0x1d, 0xc5, 0xbb, 0xfa, 0xe2, 0x3e, 0xfa, 0x1e, 0xc3, 0xf0, 0xbb, 0x58, 0xc2, 0xbc, 0x8d, 0x93, 0x8d, 0x47, 0xc1, 0xdf, 0xb3, 0xbe, 0x73}))
 	if err != nil {
 		return
 	}
+
 	inputEnvelope.Tx.SourceAccount = hardCodedSourceAccount
 	hardCodedAsset := xdr.Asset{
 		Type: xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AlphaNum4: &xdr.AssetAlphaNum4{
-			AssetCode: xdr.AssetCode4([4]byte{}),
+			AssetCode: xdr.AssetCode4([4]byte{0x55, 0x53, 0x44, 0x54}),
 			Issuer:    hardCodedDestAccount.ToAccountId(),
 		},
 	}
 	hardCodedNativeAsset := xdr.MustNewNativeAsset()
+	hardCodedInflationDest := hardCodedDestAccount.ToAccountId()
+
+	hardCodedTrustAsset, err := hardCodedAsset.ToAllowTrustOpAsset("USDT")
+	if err != nil {
+		return
+	}
+
+	hardCodedClearFlags := xdr.Uint32(3)
+	hardCodedSetFlags := xdr.Uint32(4)
+	hardCodedMasterWeight := xdr.Uint32(3)
+	hardCodedLowThresh := xdr.Uint32(1)
+	hardCodedMedThresh := xdr.Uint32(3)
+	hardCodedHighThresh := xdr.Uint32(5)
+	hardCodedHomeDomain := xdr.String32("2019=DRA;n-test")
+	hardCodedSignerKey, err := xdr.NewSignerKey(xdr.SignerKeyTypeSignerKeyTypeEd25519, xdr.Uint256([32]byte{}))
+	if err != nil {
+		return
+	}
+
+	hardCodedSigner := xdr.Signer{
+		Key:    hardCodedSignerKey,
+		Weight: xdr.Uint32(1),
+	}
+
+	hardCodedDataValue := xdr.DataValue([]byte{0x76, 0x61, 0x6c, 0x75, 0x65})
+	hardCodedSequenceNumber := xdr.SequenceNumber(100)
 	inputOperations := []xdr.Operation{
 		xdr.Operation{
 			SourceAccount: nil,
@@ -156,56 +190,435 @@ func prepareHardcodedOperationTestInput() (inputTransaction ingestio.LedgerTrans
 			SourceAccount: &hardCodedSourceAccount,
 			Body: xdr.OperationBody{
 				Type: xdr.OperationTypePathPaymentStrictReceive,
+				PathPaymentStrictReceiveOp: &xdr.PathPaymentStrictReceiveOp{
+					SendAsset:   hardCodedNativeAsset,
+					SendMax:     8951495900,
+					Destination: hardCodedDestAccount,
+					DestAsset:   hardCodedNativeAsset,
+					DestAmount:  8951495900,
+					Path:        []xdr.Asset{hardCodedAsset},
+				},
 			},
 		},
 		xdr.Operation{
-			SourceAccount: &hardCodedSourceAccount,
+			SourceAccount: nil,
 			Body: xdr.OperationBody{
 				Type: xdr.OperationTypeManageSellOffer,
+				ManageSellOfferOp: &xdr.ManageSellOfferOp{
+					Selling: hardCodedAsset,
+					Buying:  hardCodedNativeAsset,
+					Amount:  765860000,
+					Price: xdr.Price{
+						N: 128523,
+						D: 250000,
+					},
+					OfferId: 0,
+				},
 			},
 		},
 		xdr.Operation{
-			SourceAccount: &hardCodedSourceAccount,
+			SourceAccount: nil,
 			Body: xdr.OperationBody{
 				Type: xdr.OperationTypeCreatePassiveSellOffer,
+				CreatePassiveSellOfferOp: &xdr.CreatePassiveSellOfferOp{
+					Selling: hardCodedNativeAsset,
+					Buying:  hardCodedAsset,
+					Amount:  631595000,
+					Price: xdr.Price{
+						N: 99583200,
+						D: 1257990000,
+					},
+				},
+			},
+		},
+		xdr.Operation{
+			SourceAccount: nil,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypeSetOptions,
+				SetOptionsOp: &xdr.SetOptionsOp{
+					InflationDest: &hardCodedInflationDest,
+					ClearFlags:    &hardCodedClearFlags,
+					SetFlags:      &hardCodedSetFlags,
+					MasterWeight:  &hardCodedMasterWeight,
+					LowThreshold:  &hardCodedLowThresh,
+					MedThreshold:  &hardCodedMedThresh,
+					HighThreshold: &hardCodedHighThresh,
+					HomeDomain:    &hardCodedHomeDomain,
+					Signer:        &hardCodedSigner,
+				},
+			},
+		},
+		xdr.Operation{
+			SourceAccount: nil,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypeChangeTrust,
+				ChangeTrustOp: &xdr.ChangeTrustOp{
+					Line:  hardCodedAsset,
+					Limit: xdr.Int64(500000000000000000),
+				},
+			},
+		},
+		xdr.Operation{
+			SourceAccount: nil,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypeAllowTrust,
+				AllowTrustOp: &xdr.AllowTrustOp{
+					Trustor:   hardCodedSourceAccount.ToAccountId(),
+					Asset:     hardCodedTrustAsset,
+					Authorize: xdr.Uint32(0),
+				},
+			},
+		},
+		xdr.Operation{
+			SourceAccount: nil,
+			Body: xdr.OperationBody{
+				Type:        xdr.OperationTypeAccountMerge,
+				Destination: &hardCodedDestAccount,
+			},
+		},
+		xdr.Operation{
+			SourceAccount: nil,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypeInflation,
+			},
+		},
+		xdr.Operation{
+			SourceAccount: nil,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypeManageData,
+				ManageDataOp: &xdr.ManageDataOp{
+					DataName:  "test",
+					DataValue: &hardCodedDataValue,
+				},
+			},
+		},
+		xdr.Operation{
+			SourceAccount: nil,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypeBumpSequence,
+				BumpSequenceOp: &xdr.BumpSequenceOp{
+					BumpTo: hardCodedSequenceNumber,
+				},
+			},
+		},
+		xdr.Operation{
+			SourceAccount: nil,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypeManageBuyOffer,
+				ManageBuyOfferOp: &xdr.ManageBuyOfferOp{
+					Selling:   hardCodedAsset,
+					Buying:    hardCodedNativeAsset,
+					BuyAmount: 7654501001,
+					Price: xdr.Price{
+						N: 635863285,
+						D: 1818402817,
+					},
+					OfferId: 100,
+				},
+			},
+		},
+		xdr.Operation{
+			SourceAccount: nil,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypePathPaymentStrictSend,
+				PathPaymentStrictSendOp: &xdr.PathPaymentStrictSendOp{
+					SendAsset:   hardCodedNativeAsset,
+					SendAmount:  1598182,
+					Destination: hardCodedDestAccount,
+					DestAsset:   hardCodedNativeAsset,
+					DestMin:     4280460538,
+					Path:        []xdr.Asset{hardCodedAsset},
+				},
+			},
+		},
+		xdr.Operation{
+			SourceAccount: nil,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypePathPaymentStrictSend,
+				PathPaymentStrictSendOp: &xdr.PathPaymentStrictSendOp{
+					SendAsset:   hardCodedNativeAsset,
+					SendAmount:  1598182,
+					Destination: hardCodedDestAccount,
+					DestAsset:   hardCodedNativeAsset,
+					DestMin:     4280460538,
+					Path:        nil,
+				},
 			},
 		},
 	}
 	inputEnvelope.Tx.Operations = inputOperations
+	results := []xdr.OperationResult{
+		xdr.OperationResult{},
+		xdr.OperationResult{},
+		xdr.OperationResult{},
+		//need a true result for path payment receive
+		xdr.OperationResult{
+			Code: xdr.OperationResultCodeOpInner,
+			Tr: &xdr.OperationResultTr{
+				Type: xdr.OperationTypePathPaymentStrictReceive,
+				PathPaymentStrictReceiveResult: &xdr.PathPaymentStrictReceiveResult{
+					Code: xdr.PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSuccess,
+					Success: &xdr.PathPaymentStrictReceiveResultSuccess{
+						Last: xdr.SimplePaymentResult{Amount: 8951495900},
+					},
+				},
+			},
+		},
+		xdr.OperationResult{},
+		xdr.OperationResult{},
+		xdr.OperationResult{},
+		xdr.OperationResult{},
+		xdr.OperationResult{},
+		xdr.OperationResult{},
+		xdr.OperationResult{},
+		xdr.OperationResult{},
+		xdr.OperationResult{},
+		xdr.OperationResult{},
+		xdr.OperationResult{
+			Code: xdr.OperationResultCodeOpInner,
+			Tr: &xdr.OperationResultTr{
+				Type: xdr.OperationTypePathPaymentStrictSend,
+				PathPaymentStrictSendResult: &xdr.PathPaymentStrictSendResult{
+					Code: xdr.PathPaymentStrictSendResultCodePathPaymentStrictSendSuccess,
+					Success: &xdr.PathPaymentStrictSendResultSuccess{
+						Last: xdr.SimplePaymentResult{Amount: 4334043858},
+					},
+				},
+			},
+		},
+		xdr.OperationResult{
+			Code: xdr.OperationResultCodeOpInner,
+			Tr: &xdr.OperationResultTr{
+				Type: xdr.OperationTypePathPaymentStrictSend,
+				PathPaymentStrictSendResult: &xdr.PathPaymentStrictSendResult{
+					Code: xdr.PathPaymentStrictSendResultCodePathPaymentStrictSendSuccess,
+					Success: &xdr.PathPaymentStrictSendResultSuccess{
+						Last: xdr.SimplePaymentResult{Amount: 4280460538},
+					},
+				},
+			},
+		},
+	}
+	inputTransaction.Result.Result.Result.Results = &results
 	inputTransaction.Envelope.V1 = &inputEnvelope
 	return
 }
 
 func prepareHardcodedOperationTestOutputs() (transformedOperations []OperationOutput) {
+	hardCodedSourceAccountAddress := "GBT4YAEGJQ5YSFUMNKX6BPBUOCPNAIOFAVZOF6MIME2CECBMEIUXFZZN"
+	hardCodedDestAccountAddress := "GBVVRXLMNCJQW3IDDXC3X6XCH35B5Q7QXNMMFPENSOGUPQO7WO7HGZPA"
+	hardCodedAssetOutput := AssetOutput{
+		AssetType:   "credit_alphanum4",
+		AssetCode:   "USDT",
+		AssetIssuer: hardCodedDestAccountAddress,
+	}
 	transformedOperations = []OperationOutput{
 		OperationOutput{
-			SourceAccount: "GBT4YAEGJQ5YSFUMNKX6BPBUOCPNAIOFAVZOF6MIME2CECBMEIUXFZZN",
-			Type:          0,
+			SourceAccount:    hardCodedSourceAccountAddress,
+			Type:             0,
+			ApplicationOrder: 1,
 			OperationDetails: Details{
-				Account:         "GBVVRXLMNCJQW3IDDXC3X6XCH35B5Q7QXNMMFPENSOGUPQO7WO7HGZPA",
-				Funder:          "GBT4YAEGJQ5YSFUMNKX6BPBUOCPNAIOFAVZOF6MIME2CECBMEIUXFZZN",
-				StartingBalance: 25000000,
+				Account:         hardCodedDestAccountAddress,
+				Funder:          hardCodedSourceAccountAddress,
+				StartingBalance: 2.5,
 			},
 		},
 		OperationOutput{
 			Type:             1,
-			OperationDetails: Details{},
+			ApplicationOrder: 2,
+			SourceAccount:    hardCodedSourceAccountAddress,
+
+			OperationDetails: Details{
+				From:        hardCodedSourceAccountAddress,
+				To:          hardCodedDestAccountAddress,
+				Amount:      35,
+				AssetCode:   "USDT",
+				AssetType:   "credit_alphanum4",
+				AssetIssuer: hardCodedDestAccountAddress,
+			},
 		},
 		OperationOutput{
 			Type:             1,
-			OperationDetails: Details{},
+			ApplicationOrder: 3,
+			SourceAccount:    hardCodedSourceAccountAddress,
+
+			OperationDetails: Details{
+				From:      hardCodedSourceAccountAddress,
+				To:        hardCodedDestAccountAddress,
+				Amount:    35,
+				AssetType: "native",
+			},
 		},
 		OperationOutput{
 			Type:             2,
-			OperationDetails: Details{},
+			ApplicationOrder: 4,
+			SourceAccount:    hardCodedSourceAccountAddress,
+
+			OperationDetails: Details{
+				From:         hardCodedSourceAccountAddress,
+				To:           hardCodedDestAccountAddress,
+				SourceAmount: 894.6764349,
+				SourceMax:    895.14959,
+				Amount:       895.14959,
+				Path:         []AssetOutput{hardCodedAssetOutput},
+			},
 		},
 		OperationOutput{
 			Type:             3,
-			OperationDetails: Details{},
+			ApplicationOrder: 5,
+			SourceAccount:    hardCodedSourceAccountAddress,
+			OperationDetails: Details{
+				Price:  0.514092,
+				Amount: 76.586,
+				PriceR: Price{
+					Numerator:   128523,
+					Denominator: 250000,
+				},
+				SellingAssetCode:   "USDT",
+				SellingAssetType:   "credit_alphanum4",
+				SellingAssetIssuer: hardCodedDestAccountAddress,
+				BuyingAssetType:    "native",
+			},
 		},
 		OperationOutput{
 			Type:             4,
+			ApplicationOrder: 6,
+			SourceAccount:    hardCodedSourceAccountAddress,
+			OperationDetails: Details{
+				Amount: 63.1595,
+				Price:  0.0791606,
+				PriceR: Price{
+					Numerator:   99583200,
+					Denominator: 1257990000,
+				},
+				BuyingAssetCode:   "USDT",
+				BuyingAssetType:   "credit_alphanum4",
+				BuyingAssetIssuer: hardCodedDestAccountAddress,
+				SellingAssetType:  "native",
+			},
+		},
+		OperationOutput{
+			Type:             5,
+			ApplicationOrder: 7,
+			SourceAccount:    hardCodedSourceAccountAddress,
+			OperationDetails: Details{
+				InflationDest:   hardCodedDestAccountAddress,
+				ClearFlags:      []int32{1, 2},
+				SetFlags:        []int32{4},
+				MasterKeyWeight: 3,
+				LowThreshold:    1,
+				MedThreshold:    3,
+				HighThreshold:   5,
+				HomeDomain:      "2019=DRA;n-test",
+				SignerKey:       "A",
+				SignerWeight:    1,
+			},
+		},
+		OperationOutput{
+			Type:             6,
+			ApplicationOrder: 8,
+			SourceAccount:    hardCodedSourceAccountAddress,
+			OperationDetails: Details{
+				Trustor:     hardCodedSourceAccountAddress,
+				Trustee:     hardCodedDestAccountAddress,
+				Limit:       50000000000,
+				AssetCode:   "USDT",
+				AssetType:   "credit_alphanum4",
+				AssetIssuer: hardCodedDestAccountAddress,
+			},
+		},
+		OperationOutput{
+			Type:             7,
+			ApplicationOrder: 9,
+			SourceAccount:    hardCodedSourceAccountAddress,
+			OperationDetails: Details{
+				Trustee:     hardCodedSourceAccountAddress,
+				Trustor:     hardCodedDestAccountAddress,
+				Authorize:   false,
+				AssetCode:   "USDT",
+				AssetType:   "credit_alphanum4",
+				AssetIssuer: hardCodedDestAccountAddress,
+			},
+		},
+		OperationOutput{
+			Type:             8,
+			ApplicationOrder: 10,
+			SourceAccount:    hardCodedSourceAccountAddress,
+			OperationDetails: Details{
+				Account: hardCodedSourceAccountAddress,
+				Into:    hardCodedDestAccountAddress,
+			},
+		},
+		OperationOutput{
+			Type:             9,
+			ApplicationOrder: 11,
+			SourceAccount:    hardCodedSourceAccountAddress,
 			OperationDetails: Details{},
+		},
+		OperationOutput{
+			Type:             10,
+			ApplicationOrder: 12,
+			SourceAccount:    hardCodedSourceAccountAddress,
+			OperationDetails: Details{
+				Name:  "test",
+				Value: base64.StdEncoding.EncodeToString([]byte{0x76, 0x61, 0x6c, 0x75, 0x65}),
+			},
+		},
+		OperationOutput{
+			Type:             11,
+			ApplicationOrder: 13,
+			SourceAccount:    hardCodedSourceAccountAddress,
+			OperationDetails: Details{
+				BumpTo: "100",
+			},
+		},
+		OperationOutput{
+			Type:             12,
+			ApplicationOrder: 14,
+			SourceAccount:    hardCodedSourceAccountAddress,
+			OperationDetails: Details{
+				Price:  0.34968230309,
+				Amount: 765.4501001,
+				PriceR: Price{
+					Numerator:   635863285,
+					Denominator: 1818402817,
+				},
+				SellingAssetCode:   "USDT",
+				SellingAssetType:   "credit_alphanum4",
+				SellingAssetIssuer: hardCodedDestAccountAddress,
+				BuyingAssetType:    "native",
+				OfferID:            100,
+			},
+		},
+		OperationOutput{
+			Type:             13,
+			ApplicationOrder: 15,
+			SourceAccount:    hardCodedSourceAccountAddress,
+			OperationDetails: Details{
+				From:            hardCodedSourceAccountAddress,
+				To:              hardCodedDestAccountAddress,
+				SourceAmount:    0.1598182,
+				DestinationMin:  "428.0460538",
+				Amount:          433.4043858,
+				Path:            []AssetOutput{hardCodedAssetOutput},
+				SourceAssetType: "native",
+				AssetType:       "native",
+			},
+		},
+		OperationOutput{
+			Type:             13,
+			ApplicationOrder: 16,
+			SourceAccount:    hardCodedSourceAccountAddress,
+			OperationDetails: Details{
+				From:            hardCodedSourceAccountAddress,
+				To:              hardCodedDestAccountAddress,
+				SourceAmount:    0.1598182,
+				DestinationMin:  "428.0460538",
+				Amount:          428.0460538,
+				Path:            nil,
+				SourceAssetType: "native",
+				AssetType:       "native",
+			},
 		},
 	}
 	return

--- a/internal/transform/operation_test.go
+++ b/internal/transform/operation_test.go
@@ -21,7 +21,11 @@ func TestTransformOperation(t *testing.T) {
 		wantOutput OperationOutput
 		wantErr    error
 	}
-	genericInput := operationInput{genericOperation, 1, genericLedgerTransaction}
+	genericInput := operationInput{
+		operation:   genericOperation,
+		index:       1,
+		transaction: genericLedgerTransaction,
+	}
 
 	negativeOpTypeInput := genericInput
 	negativeOpTypeEnvelope := genericEnvelope

--- a/internal/transform/operation_test.go
+++ b/internal/transform/operation_test.go
@@ -263,9 +263,9 @@ func prepareHardcodedOperationTestInput() (inputTransaction ingestio.LedgerTrans
 			Body: xdr.OperationBody{
 				Type: xdr.OperationTypeAllowTrust,
 				AllowTrustOp: &xdr.AllowTrustOp{
-					Trustor:   hardCodedSourceAccount.ToAccountId(),
+					Trustor:   hardCodedDestAccount.ToAccountId(),
 					Asset:     hardCodedTrustAsset,
-					Authorize: xdr.Uint32(0),
+					Authorize: xdr.Uint32(1),
 				},
 			},
 		},
@@ -359,7 +359,7 @@ func prepareHardcodedOperationTestInput() (inputTransaction ingestio.LedgerTrans
 				PathPaymentStrictReceiveResult: &xdr.PathPaymentStrictReceiveResult{
 					Code: xdr.PathPaymentStrictReceiveResultCodePathPaymentStrictReceiveSuccess,
 					Success: &xdr.PathPaymentStrictReceiveResultSuccess{
-						Last: xdr.SimplePaymentResult{Amount: 8951495900},
+						Last: xdr.SimplePaymentResult{Amount: 8946764349},
 					},
 				},
 			},
@@ -455,12 +455,14 @@ func prepareHardcodedOperationTestOutputs() (transformedOperations []OperationOu
 			SourceAccount:    hardCodedSourceAccountAddress,
 
 			OperationDetails: Details{
-				From:         hardCodedSourceAccountAddress,
-				To:           hardCodedDestAccountAddress,
-				SourceAmount: 894.6764349,
-				SourceMax:    895.14959,
-				Amount:       895.14959,
-				Path:         []AssetOutput{hardCodedAssetOutput},
+				From:            hardCodedSourceAccountAddress,
+				To:              hardCodedDestAccountAddress,
+				SourceAmount:    894.6764349,
+				SourceMax:       895.14959,
+				Amount:          895.14959,
+				SourceAssetType: "native",
+				AssetType:       "native",
+				Path:            []AssetOutput{hardCodedAssetOutput},
 			},
 		},
 		OperationOutput{
@@ -502,16 +504,18 @@ func prepareHardcodedOperationTestOutputs() (transformedOperations []OperationOu
 			ApplicationOrder: 7,
 			SourceAccount:    hardCodedSourceAccountAddress,
 			OperationDetails: Details{
-				InflationDest:   hardCodedDestAccountAddress,
-				ClearFlags:      []int32{1, 2},
-				SetFlags:        []int32{4},
-				MasterKeyWeight: 3,
-				LowThreshold:    1,
-				MedThreshold:    3,
-				HighThreshold:   5,
-				HomeDomain:      "2019=DRA;n-test",
-				SignerKey:       "A",
-				SignerWeight:    1,
+				InflationDest:    hardCodedDestAccountAddress,
+				ClearFlags:       []int32{1, 2},
+				ClearFlagsString: []string{"auth_required", "auth_revocable"},
+				SetFlags:         []int32{4},
+				SetFlagsString:   []string{"auth_immutable"},
+				MasterKeyWeight:  3,
+				LowThreshold:     1,
+				MedThreshold:     3,
+				HighThreshold:    5,
+				HomeDomain:       "2019=DRA;n-test",
+				SignerKey:        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+				SignerWeight:     1,
 			},
 		},
 		OperationOutput{
@@ -534,10 +538,10 @@ func prepareHardcodedOperationTestOutputs() (transformedOperations []OperationOu
 			OperationDetails: Details{
 				Trustee:     hardCodedSourceAccountAddress,
 				Trustor:     hardCodedDestAccountAddress,
-				Authorize:   false,
+				Authorize:   true,
 				AssetCode:   "USDT",
 				AssetType:   "credit_alphanum4",
-				AssetIssuer: hardCodedDestAccountAddress,
+				AssetIssuer: hardCodedSourceAccountAddress,
 			},
 		},
 		OperationOutput{
@@ -577,7 +581,7 @@ func prepareHardcodedOperationTestOutputs() (transformedOperations []OperationOu
 			ApplicationOrder: 14,
 			SourceAccount:    hardCodedSourceAccountAddress,
 			OperationDetails: Details{
-				Price:  0.34968230309,
+				Price:  0.3496823,
 				Amount: 765.4501001,
 				PriceR: Price{
 					Numerator:   635863285,

--- a/internal/transform/schema.go
+++ b/internal/transform/schema.go
@@ -76,14 +76,14 @@ type Details struct {
 	BuyingAssetType    string        `json:"buying_asset_type"`
 	From               string        `json:"from"`
 	Funder             string        `json:"funder"`
-	HighThreshold      int32         `json:"high_threshold"`
+	HighThreshold      uint32        `json:"high_threshold"`
 	HomeDomain         string        `json:"home_domain"`
 	InflationDest      string        `json:"inflation_dest"`
 	Into               string        `json:"into"`
 	Limit              float64       `json:"limit"`
-	LowThreshold       int32         `json:"low_threshold"`
-	MasterKeyWeight    int32         `json:"master_key_weight"`
-	MedThreshold       int32         `json:"med_threshold"`
+	LowThreshold       uint32        `json:"low_threshold"`
+	MasterKeyWeight    uint32        `json:"master_key_weight"`
+	MedThreshold       uint32        `json:"med_threshold"`
 	Name               string        `json:"name"`
 	OfferID            int64         `json:"offer_id"`
 	Path               []AssetOutput `json:"path"`
@@ -95,7 +95,7 @@ type Details struct {
 	SetFlags           []int32       `json:"set_flags"`
 	SetFlagsString     []string      `json:"set_flags_s"`
 	SignerKey          string        `json:"signer_key"`
-	SignerWeight       int32         `json:"signer_weight"`
+	SignerWeight       uint32        `json:"signer_weight"`
 	SourceAmount       float64       `json:"source_amount"`
 	SourceAssetCode    string        `json:"source_asset_code"`
 	SourceAssetIssuer  string        `json:"source_asset_issuer"`

--- a/internal/transform/schema.go
+++ b/internal/transform/schema.go
@@ -22,7 +22,7 @@ type LedgerOutput struct {
 	ProtocolVersion            int32     `json:"protocol_version"`
 
 	/*
-		TODO: implement these three fields
+		TODO implement these three fields
 			CreatedAt time.Time //timestamp of table entry creation time
 			UpdatedAt time.Time //timestamp of table entry update time
 			ImporterVersion int32 //version of the ingestion system
@@ -46,7 +46,81 @@ type TransactionOutput struct {
 	Successful       bool      `json:"successful"`
 
 	/*
-		TODO: implement
+		TODO implement
 			updated_at time.Time //timestamp of table entry update time
 	*/
+}
+
+//OperationOutput is a representation of an operation that aligns with the BigQuery table history_operations
+type OperationOutput struct {
+	SourceAccount    string  `json:"source_account"`
+	Type             int32   `json:"type"`
+	ApplicationOrder int32   `json:"application_order"`
+	OperationDetails Details `json:"details"`
+	/*
+		TODO implement
+			TransactionID int64 // history table mapping that connect operations to their parent transaction
+	*/
+}
+
+//Details is a struct that provides additional information about operations in a way that aligns with the details struct in the BigQuery table history_operations
+type Details struct {
+	Account            string        `json:"account"`
+	Amount             float64       `json:"amount"`
+	AssetCode          string        `json:"asset_code"`
+	AssetIssuer        string        `json:"asset_issuer"`
+	AssetType          string        `json:"asset_type"`
+	Authorize          bool          `json:"authorize"`
+	BuyingAssetCode    string        `json:"buying_asset_code"`
+	BuyingAssetIssuer  string        `json:"buying_asset_issuer"`
+	BuyingAssetType    string        `json:"buying_asset_type"`
+	From               string        `json:"from"`
+	Funder             string        `json:"funder"`
+	HighThreshold      int32         `json:"high_threshold"`
+	HomeDomain         string        `json:"home_domain"`
+	InflationDest      string        `json:"inflation_dest"`
+	Into               string        `json:"into"`
+	Limit              float64       `json:"limit"`
+	LowThreshold       int32         `json:"low_threshold"`
+	MasterKeyWeight    int32         `json:"master_key_weight"`
+	MedThreshold       int32         `json:"med_threshold"`
+	Name               string        `json:"name"`
+	OfferID            int64         `json:"offer_id"`
+	Path               []AssetOutput `json:"path"`
+	Price              float64       `json:"price"`
+	PriceR             Price         `json:"price_r"`
+	SellingAssetCode   string        `json:"selling_asset_code"`
+	SellingAssetIssuer string        `json:"selling_asset_issuer"`
+	SellingAssetType   string        `json:"selling_asset_type"`
+	SetFlags           []int32       `json:"set_flags"`
+	SetFlagsString     []string      `json:"set_flags_s"`
+	SignerKey          string        `json:"signer_key"`
+	SignerWeight       int32         `json:"signer_weight"`
+	SourceAmount       float64       `json:"source_amount"`
+	SourceAssetCode    string        `json:"source_asset_code"`
+	SourceAssetIssuer  string        `json:"source_asset_issuer"`
+	SourceAssetType    string        `json:"source_asset_type"`
+	SourceMax          float64       `json:"source_max"`
+	StartingBalance    float64       `json:"starting_balance"`
+	To                 string        `json:"to"`
+	Trustee            string        `json:"trustee"`
+	Trustor            string        `json:"trustor"`
+	Value              string        `json:"value"`
+	ClearFlags         []int32       `json:"clear_flags"`
+	ClearFlagsString   []string      `json:"clear_flags_s"`
+	DestinationMin     string        `json:"destination_min"`
+	BumpTo             string        `json:"bump_to"`
+}
+
+//Price represents the price of an asset as a fraction
+type Price struct {
+	Numerator   int32 `json:"n"`
+	Denominator int32 `json:"d"`
+}
+
+//AssetOutput is a representation of an asset that aligns with the BigQuery table history_assets
+type AssetOutput struct {
+	AssetCode   string `json:"asset_code"`
+	AssetIssuer string `json:"asset_issuer"`
+	AssetType   string `json:"asset_type"`
 }

--- a/internal/transform/schema.go
+++ b/internal/transform/schema.go
@@ -105,7 +105,7 @@ type Details struct {
 	To                 string        `json:"to"`
 	Trustee            string        `json:"trustee"`
 	Trustor            string        `json:"trustor"`
-	Value              string        `json:"value"`
+	Value              string        `json:"value"` //base64 encoding of bytes
 	ClearFlags         []int32       `json:"clear_flags"`
 	ClearFlagsString   []string      `json:"clear_flags_s"`
 	DestinationMin     string        `json:"destination_min"`

--- a/internal/utils/main.go
+++ b/internal/utils/main.go
@@ -65,6 +65,11 @@ func CreateSampleTx(sequence int64) xdr.TransactionEnvelope {
 	return env
 }
 
+//ConvertStroopValueToReal converts a value in stroops, the smallest amount unit, into real units
+func ConvertStroopValueToReal(input xdr.Int64) float64 {
+	return float64(input) * float64(0.0000001)
+}
+
 //CreateSampleResultMeta creates Transaction results with the desired success flag and number of sub operation results
 func CreateSampleResultMeta(successful bool, subOperationCount int) xdr.TransactionResultMeta {
 	resultCode := xdr.TransactionResultCodeTxFailed

--- a/internal/utils/main.go
+++ b/internal/utils/main.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"encoding/hex"
 	"errors"
+	"math/big"
 	"time"
 
 	"github.com/stellar/go/keypair"
@@ -67,7 +68,8 @@ func CreateSampleTx(sequence int64) xdr.TransactionEnvelope {
 
 //ConvertStroopValueToReal converts a value in stroops, the smallest amount unit, into real units
 func ConvertStroopValueToReal(input xdr.Int64) float64 {
-	return float64(input) * float64(0.0000001)
+	output, _ := big.NewRat(int64(input), int64(10000000)).Float64()
+	return output
 }
 
 //CreateSampleResultMeta creates Transaction results with the desired success flag and number of sub operation results


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What

This PR adds the transform function for operations. The function takes in an operation in the format described by the ingestion system, and transforms it into a custom struct suitable for BigQuery. Closes #37 
### Why

The transform function will be part of the larger CLI tool. This function will allow us to create a command that retrieves operations and exports them in the form we want.

### Known limitations
