### PR TITLE
transform: added transform for offers

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,7 @@ github.com/stellar/go v0.0.0-20200713182524-95680941e5c1/go.mod h1:8HtdR7lVqG6yR
 github.com/stellar/go v0.0.0-20200715144943-c92667eaba34 h1:CVr9JYO2JWIMGFYswm9eQM3cr+xYcxkNwfCtMMoREPk=
 github.com/stellar/go v0.0.0-20200716132855-ded108912a76 h1:Xm1Q8GVki11Wp93f/uSrT/hMM/83ADGddZ/OHW+GFZQ=
 github.com/stellar/go v0.0.0-20200721154454-f77b3b518d6d h1:LEeIEcOZgFuQU+O8rzuZ8OHkCiiLnSwBlGtPmLtgbEI=
+github.com/stellar/go v0.0.0-20200722014408-03068ea1cc98 h1:Tc3ui2+R4yUPUjWk1iDhPoG7/uIKsZMAEgEIy5LMSDs=
 github.com/stellar/go-xdr v0.0.0-20180917104419-0bc96f33a18e h1:n/hfey8pO+RYMoGXyvyzuw5pdO8IFDoyAL/g5OiCesY=
 github.com/stellar/go-xdr v0.0.0-20180917104419-0bc96f33a18e/go.mod h1:gpOLVzy6TVYTQ3LvHSN9RJC700FkhFCpSE82u37aNRM=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=

--- a/go.sum
+++ b/go.sum
@@ -260,6 +260,7 @@ github.com/stellar/go v0.0.0-20200713182524-95680941e5c1 h1:TLRHifcmPq8LOWqtLRIB
 github.com/stellar/go v0.0.0-20200713182524-95680941e5c1/go.mod h1:8HtdR7lVqG6yRCbn4p820iOmMmcdhVhV+kxS/ZhmcKk=
 github.com/stellar/go v0.0.0-20200715144943-c92667eaba34 h1:CVr9JYO2JWIMGFYswm9eQM3cr+xYcxkNwfCtMMoREPk=
 github.com/stellar/go v0.0.0-20200716132855-ded108912a76 h1:Xm1Q8GVki11Wp93f/uSrT/hMM/83ADGddZ/OHW+GFZQ=
+github.com/stellar/go v0.0.0-20200721154454-f77b3b518d6d h1:LEeIEcOZgFuQU+O8rzuZ8OHkCiiLnSwBlGtPmLtgbEI=
 github.com/stellar/go-xdr v0.0.0-20180917104419-0bc96f33a18e h1:n/hfey8pO+RYMoGXyvyzuw5pdO8IFDoyAL/g5OiCesY=
 github.com/stellar/go-xdr v0.0.0-20180917104419-0bc96f33a18e/go.mod h1:gpOLVzy6TVYTQ3LvHSN9RJC700FkhFCpSE82u37aNRM=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,7 @@ github.com/fatih/structs v1.0.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gavv/monotime v0.0.0-20161010190848-47d58efa6955/go.mod h1:vmp8DIyckQMXOPl0AQVHt+7n5h7Gb7hS6CUydiV8QeA=
+github.com/gdexlab/go-render v1.0.1 h1:rxqB3vo5s4n1kF0ySmoNeSPRYkEsyHgln4jFIQY7v0U=
 github.com/gdexlab/go-render v1.0.1/go.mod h1:wRi5nW2qfjiGj4mPukH4UV0IknS1cHD4VgFTmJX5JzM=
 github.com/getlantern/deepcopy v0.0.0-20160317154340-7f45deb8130a h1:yU/FENpkHYISWsQrbr3pcZOBj0EuRjPzNc1+dTCLu44=
 github.com/getlantern/deepcopy v0.0.0-20160317154340-7f45deb8130a/go.mod h1:AEugkNu3BjBxyz958nJ5holD9PRjta6iprcoUauDbU4=

--- a/internal/transform/account.go
+++ b/internal/transform/account.go
@@ -71,8 +71,8 @@ func TransformAccount(ledgerEntry xdr.LedgerEntry) (AccountOutput, error) {
 	outputThreshHigh := int32(accountEntry.ThresholdHigh())
 
 	outputLastModifiedLedger := int64(ledgerEntry.LastModifiedLedgerSeq)
-	if outputSequenceNumber < 0 {
-		return AccountOutput{}, fmt.Errorf("Last modified ledger number is negative (%d) for account: %s", outputSequenceNumber, outputID)
+	if outputLastModifiedLedger < 0 {
+		return AccountOutput{}, fmt.Errorf("Last modified ledger number is negative (%d) for account: %s", outputLastModifiedLedger, outputID)
 	}
 
 	transformedAccount := AccountOutput{

--- a/internal/transform/offer.go
+++ b/internal/transform/offer.go
@@ -1,0 +1,65 @@
+package transform
+
+import (
+	"fmt"
+	"strconv"
+
+	ingestio "github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/xdr"
+)
+
+//TransformOffer converts an account from the history archive ingestion system into a form suitable for BigQuery
+func TransformOffer(ledgerChange ingestio.Change) (OfferOutput, error) {
+	outputOfferDeleted := false
+	ledgerEntry := ledgerChange.Post
+	if ledgerChange.LedgerEntryChangeType() == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
+		outputOfferDeleted = true
+		ledgerEntry = ledgerChange.Pre
+	}
+	offerEntry, offerFound := ledgerEntry.Data.GetOffer()
+	if !offerFound {
+		return OfferOutput{}, fmt.Errorf("Could not extract offer data from ledger entry; actual type is %s", ledgerEntry.Data.Type)
+	}
+
+	outputSellerID, err := offerEntry.SellerId.GetAddress()
+	if err != nil {
+		return OfferOutput{}, err
+	}
+	outputOfferID := int64(offerEntry.OfferId)
+
+	outputSellingAsset, _ := xdr.MarshalBase64(offerEntry.Selling) //check err
+	outputBuyingAsset, _ := xdr.MarshalBase64(offerEntry.Buying)
+
+	outputAmount := int64(offerEntry.Amount) //check neg
+
+	outputPriceN := int32(offerEntry.Price.N) //check neg
+	outputPriceD := int32(offerEntry.Price.D) //check neg and non 0
+
+	outputPrice, _ := strconv.ParseFloat(offerEntry.Price.String(), 64) //check neg; err
+
+	outputFlags := uint32(offerEntry.Flags)
+	if outputFlags < 0 {
+		return OfferOutput{}, fmt.Errorf("Flags are negative (%d)for account: %s", outputFlags, outputSellerID)
+	}
+
+	outputLastModifiedLedger := int64(ledgerEntry.LastModifiedLedgerSeq)
+	if outputLastModifiedLedger < 0 {
+		return OfferOutput{}, fmt.Errorf("Last modified ledger number is negative (%d) for account: %s", outputLastModifiedLedger, outputSellerID)
+	}
+
+	//outputDeleted := offerEntry.
+
+	transformedOffer := OfferOutput{
+		SellerID:           outputSellerID,
+		OfferID:            outputOfferID,
+		SellingAsset:       outputSellingAsset,
+		BuyingAsset:        outputBuyingAsset,
+		Amount:             outputAmount,
+		PriceN:             outputPriceN,
+		PriceD:             outputPriceD,
+		Price:              outputPrice,
+		LastModifiedLedger: outputLastModifiedLedger,
+		Deleted:            outputOfferDeleted,
+	}
+	return transformedOffer, nil
+}

--- a/internal/transform/offer.go
+++ b/internal/transform/offer.go
@@ -14,6 +14,10 @@ func TransformOffer(ledgerChange ingestio.Change) (OfferOutput, error) {
 		ledgerEntry = ledgerChange.Pre
 	}
 
+	if ledgerEntry == nil {
+		return OfferOutput{}, fmt.Errorf("Ledger entry is nil")
+	}
+
 	offerEntry, offerFound := ledgerEntry.Data.GetOffer()
 	if !offerFound {
 		return OfferOutput{}, fmt.Errorf("Could not extract offer data from ledger entry; actual type is %s", ledgerEntry.Data.Type)
@@ -23,7 +27,8 @@ func TransformOffer(ledgerChange ingestio.Change) (OfferOutput, error) {
 	if err != nil {
 		return OfferOutput{}, err
 	}
-	outputOfferID := int64(offerEntry.OfferId) //neg
+
+	outputOfferID := int64(offerEntry.OfferId)
 	if outputOfferID < 0 {
 		return OfferOutput{}, fmt.Errorf("OfferID is negative (%d) for offer from account: %s", outputOfferID, outputSellerID)
 	}

--- a/internal/transform/offer.go
+++ b/internal/transform/offer.go
@@ -9,10 +9,8 @@ import (
 
 //TransformOffer converts an account from the history archive ingestion system into a form suitable for BigQuery
 func TransformOffer(ledgerChange ingestio.Change) (OfferOutput, error) {
-	outputOfferDeleted := false
 	ledgerEntry := ledgerChange.Post
 	if ledgerChange.LedgerEntryChangeType() == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
-		outputOfferDeleted = true
 		ledgerEntry = ledgerChange.Pre
 	}
 
@@ -85,7 +83,6 @@ func TransformOffer(ledgerChange ingestio.Change) (OfferOutput, error) {
 		Price:              outputPrice,
 		Flags:              outputFlags,
 		LastModifiedLedger: outputLastModifiedLedger,
-		Deleted:            outputOfferDeleted,
 	}
 	return transformedOffer, nil
 }

--- a/internal/transform/offer_test.go
+++ b/internal/transform/offer_test.go
@@ -1,53 +1,168 @@
 package transform
 
 import (
-	"context"
 	"fmt"
-	"io"
 	"testing"
 
 	ingestio "github.com/stellar/go/exp/ingest/io"
-	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/xdr"
-	"github.com/stellar/stellar-etl/internal/utils"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestLive(t *testing.T) {
-	//30715263 has deleted stuff
-	sequence := uint32(30715263) //30522111, 30522175, 30715263, 30715199
-	archiveURL := "http://history.stellar.org/prd/core-live/core_live_001"
-	archive, err := historyarchive.Connect(
-		archiveURL,
-		historyarchive.ConnectOptions{Context: context.Background()},
-	)
-	utils.PanicOnError(err)
-	/*for s := 30715281; s > 0; s-- {
-		_, err := ingestio.MakeSingleLedgerStateReader(context.Background(), archive, uint32(s))
-		if err == nil {
-			fmt.Println(s)
-		} else if s%1000 == 0 {
-			fmt.Printf("not working %d\n", s)
-		}
-	}*/
-	stateReader, err := ingestio.MakeSingleLedgerStateReader(context.Background(), archive, sequence)
-	utils.PanicOnError(err)
-	for {
-		change, err := stateReader.Read()
-		if err == io.EOF {
-			break
-		}
-		utils.PanicOnError(err)
-		if change.Type == xdr.LedgerEntryTypeOffer {
-			if change.LedgerEntryChangeType() == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
-				fmt.Println("deleted")
-			}
-			converted, err := TransformOffer(change)
+func TestTransformOffer(t *testing.T) {
+	type transformTest struct {
+		input      ingestio.Change
+		wantOutput OfferOutput
+		wantErr    error
+	}
+	genericAccountID, err := xdr.NewAccountId(xdr.PublicKeyTypePublicKeyTypeEd25519, xdr.Uint256([32]byte{}))
+	assert.NoError(t, err)
+	genericAccountAddress, err := genericAccountID.GetAddress()
+	assert.NoError(t, err)
 
-			if converted.OfferID == 260678415 {
-				fmt.Println("deleted")
-			}
-			utils.PanicOnError(err)
-		}
+	hardCodedInput, err := prepareHardcodedOfferTestInput()
+	assert.NoError(t, err)
+	hardCodedOutput := prepareHardcodedOfferTestOutput()
 
+	tests := []transformTest{
+		{
+			ingestio.Change{
+				Type: xdr.LedgerEntryTypeAccount,
+				Post: &xdr.LedgerEntry{
+					Data: xdr.LedgerEntryData{
+						Type: xdr.LedgerEntryTypeAccount,
+					},
+				},
+			},
+			OfferOutput{}, fmt.Errorf("Could not extract offer data from ledger entry; actual type is LedgerEntryTypeAccount"),
+		},
+		{
+			wrapOfferEntry(xdr.OfferEntry{
+				SellerId: genericAccountID,
+				OfferId:  -1,
+			}, 0),
+			OfferOutput{}, fmt.Errorf("OfferID is negative (-1) for offer from account: %s", genericAccountAddress),
+		},
+		{
+			wrapOfferEntry(xdr.OfferEntry{
+				SellerId: genericAccountID,
+				Amount:   -2,
+			}, 0),
+			OfferOutput{}, fmt.Errorf("Amount is negative (-2) for offer 0"),
+		},
+		{
+			wrapOfferEntry(xdr.OfferEntry{
+				SellerId: genericAccountID,
+				Price: xdr.Price{
+					N: -3,
+					D: 10,
+				},
+			}, 0),
+			OfferOutput{}, fmt.Errorf("Price numerator is negative (-3) for offer 0"),
+		},
+		{
+			wrapOfferEntry(xdr.OfferEntry{
+				SellerId: genericAccountID,
+				Price: xdr.Price{
+					N: 5,
+					D: -4,
+				},
+			}, 0),
+			OfferOutput{}, fmt.Errorf("Price denominator is negative (-4) for offer 0"),
+		},
+		{
+			wrapOfferEntry(xdr.OfferEntry{
+				SellerId: genericAccountID,
+				Price: xdr.Price{
+					N: 5,
+					D: 0,
+				},
+			}, 0),
+			OfferOutput{}, fmt.Errorf("Price denominator is 0 for offer 0"),
+		},
+		{
+			hardCodedInput,
+			hardCodedOutput, nil,
+		},
+	}
+
+	for _, test := range tests {
+		actualOutput, actualError := TransformOffer(test.input)
+		assert.Equal(t, test.wantErr, actualError)
+		assert.Equal(t, test.wantOutput, actualOutput)
+	}
+}
+
+func wrapOfferEntry(offerEntry xdr.OfferEntry, lastModified int) ingestio.Change {
+	return ingestio.Change{
+		Type: xdr.LedgerEntryTypeOffer,
+		Pre:  nil,
+		Post: &xdr.LedgerEntry{
+			LastModifiedLedgerSeq: xdr.Uint32(lastModified),
+			Data: xdr.LedgerEntryData{
+				Type:  xdr.LedgerEntryTypeOffer,
+				Offer: &offerEntry,
+			},
+		},
+	}
+}
+
+func prepareHardcodedOfferTestInput() (ledgerChange ingestio.Change, err error) {
+	hardCodedAccountID, err := xdr.NewAccountId(xdr.PublicKeyTypePublicKeyTypeEd25519, xdr.Uint256([32]byte{9, 13, 119, 101, 93, 2, 49, 146, 108, 232, 96, 108, 62, 49, 254, 143, 121, 165, 44, 237, 34, 197, 125, 11, 184, 24, 88, 236, 241, 192, 185, 158}))
+	if err != nil {
+		return
+	}
+
+	hardCodedAssetIssuer, err := xdr.NewAccountId(xdr.PublicKeyTypePublicKeyTypeEd25519, xdr.Uint256([32]byte{234, 172, 104, 212, 208, 227, 123, 76, 36, 194, 83, 105, 22, 232, 48, 115, 95, 3, 45, 13, 107, 42, 28, 143, 202, 59, 197, 162, 94, 8, 62, 58}))
+	if err != nil {
+		return
+	}
+	hardCodedBuyingAsset := xdr.Asset{
+		Type: xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AlphaNum4: &xdr.AssetAlphaNum4{
+			AssetCode: xdr.AssetCode4([4]byte{66, 82, 76, 0}),
+			Issuer:    hardCodedAssetIssuer,
+		},
+	}
+	ledgerChange = ingestio.Change{
+		Type: xdr.LedgerEntryTypeOffer,
+		Pre:  nil,
+		Post: &xdr.LedgerEntry{
+			LastModifiedLedgerSeq: xdr.Uint32(30715263),
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeOffer,
+				Offer: &xdr.OfferEntry{
+					SellerId: hardCodedAccountID,
+					OfferId:  260678439,
+					Selling: xdr.Asset{
+						Type: xdr.AssetTypeAssetTypeNative,
+					},
+					Buying: hardCodedBuyingAsset,
+					Amount: 2628450327,
+					Price: xdr.Price{
+						N: 920936891,
+						D: 1790879058,
+					},
+					Flags: 2,
+				},
+			},
+		},
+	}
+	return
+}
+
+func prepareHardcodedOfferTestOutput() OfferOutput {
+	return OfferOutput{
+		SellerID:           "GAEQ253FLUBDDETM5BQGYPRR72HXTJJM5URMK7ILXAMFR3HRYC4Z43IR",
+		OfferID:            260678439,
+		SellingAsset:       "AAAAAA==",
+		BuyingAsset:        "AAAAAUJSTAAAAAAA6qxo1NDje0wkwlNpFugwc18DLQ1rKhyPyjvFol4IPjo=",
+		Amount:             2628450327,
+		PriceN:             920936891,
+		PriceD:             1790879058,
+		Price:              0.5142373444404865,
+		Flags:              2,
+		LastModifiedLedger: 30715263,
+		Deleted:            false,
 	}
 }

--- a/internal/transform/offer_test.go
+++ b/internal/transform/offer_test.go
@@ -163,6 +163,5 @@ func prepareHardcodedOfferTestOutput() OfferOutput {
 		Price:              0.5142373444404865,
 		Flags:              2,
 		LastModifiedLedger: 30715263,
-		Deleted:            false,
 	}
 }

--- a/internal/transform/offer_test.go
+++ b/internal/transform/offer_test.go
@@ -1,0 +1,53 @@
+package transform
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	ingestio "github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/historyarchive"
+	"github.com/stellar/go/xdr"
+	"github.com/stellar/stellar-etl/internal/utils"
+)
+
+func TestLive(t *testing.T) {
+	//30715263 has deleted stuff
+	sequence := uint32(30715263) //30522111, 30522175, 30715263, 30715199
+	archiveURL := "http://history.stellar.org/prd/core-live/core_live_001"
+	archive, err := historyarchive.Connect(
+		archiveURL,
+		historyarchive.ConnectOptions{Context: context.Background()},
+	)
+	utils.PanicOnError(err)
+	/*for s := 30715281; s > 0; s-- {
+		_, err := ingestio.MakeSingleLedgerStateReader(context.Background(), archive, uint32(s))
+		if err == nil {
+			fmt.Println(s)
+		} else if s%1000 == 0 {
+			fmt.Printf("not working %d\n", s)
+		}
+	}*/
+	stateReader, err := ingestio.MakeSingleLedgerStateReader(context.Background(), archive, sequence)
+	utils.PanicOnError(err)
+	for {
+		change, err := stateReader.Read()
+		if err == io.EOF {
+			break
+		}
+		utils.PanicOnError(err)
+		if change.Type == xdr.LedgerEntryTypeOffer {
+			if change.LedgerEntryChangeType() == xdr.LedgerEntryChangeTypeLedgerEntryRemoved {
+				fmt.Println("deleted")
+			}
+			converted, err := TransformOffer(change)
+
+			if converted.OfferID == 260678415 {
+				fmt.Println("deleted")
+			}
+			utils.PanicOnError(err)
+		}
+
+	}
+}

--- a/internal/transform/offer_test.go
+++ b/internal/transform/offer_test.go
@@ -117,6 +117,7 @@ func prepareHardcodedOfferTestInput() (ledgerChange ingestio.Change, err error) 
 	if err != nil {
 		return
 	}
+
 	hardCodedBuyingAsset := xdr.Asset{
 		Type: xdr.AssetTypeAssetTypeCreditAlphanum4,
 		AlphaNum4: &xdr.AssetAlphaNum4{
@@ -124,6 +125,7 @@ func prepareHardcodedOfferTestInput() (ledgerChange ingestio.Change, err error) 
 			Issuer:    hardCodedAssetIssuer,
 		},
 	}
+
 	ledgerChange = ingestio.Change{
 		Type: xdr.LedgerEntryTypeOffer,
 		Pre:  nil,

--- a/internal/transform/schema.go
+++ b/internal/transform/schema.go
@@ -142,3 +142,18 @@ type AssetOutput struct {
 	AssetIssuer string `json:"asset_issuer"`
 	AssetType   string `json:"asset_type"`
 }
+
+//OfferOutput is a representation of an offer that aligns with the BigQuery table offers
+type OfferOutput struct {
+	SellerID           string  `json:"seller_id"`
+	OfferID            int64   `json:"offer_id"`
+	SellingAsset       string  `json:"selling_asset"`
+	BuyingAsset        string  `json:"buying_asset"`
+	Amount             int64   `json:"amount"`
+	PriceN             int32   `json:"pricen"`
+	PriceD             int32   `json:"priced"`
+	Price              float64 `json:"aspriceset_code"`
+	Flags              uint32  `json:"flags"`
+	LastModifiedLedger int64   `json:"last_modified_ledger"`
+	Deleted            bool    `json:"deleted"`
+}

--- a/internal/transform/schema.go
+++ b/internal/transform/schema.go
@@ -155,5 +155,9 @@ type OfferOutput struct {
 	Price              float64 `json:"aspriceset_code"`
 	Flags              uint32  `json:"flags"`
 	LastModifiedLedger int64   `json:"last_modified_ledger"`
-	Deleted            bool    `json:"deleted"`
+	/*
+		TODO implement
+			Deleted bool `json:"deleted"` // need to see operation that deletes offer to know what this value should be
+	*/
+
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What

This PR adds the transform function for offers. The function takes in an offer in the format described by the ingestion system, and transforms it into a custom struct suitable for BigQuery. Closes #36.
### Why

The transform function will be part of the larger CLI tool. This function will allow us to create a command that retrieves offers and exports them in the form we want.

### Known limitations
The deleted field is dependent on information about operations. Right now, it is not included in the OfferOutput struct.