### PR TITLE
transform: implemented alternative ids

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,10 @@ github.com/stellar/go v0.0.0-20200715144943-c92667eaba34 h1:CVr9JYO2JWIMGFYswm9e
 github.com/stellar/go v0.0.0-20200716132855-ded108912a76 h1:Xm1Q8GVki11Wp93f/uSrT/hMM/83ADGddZ/OHW+GFZQ=
 github.com/stellar/go v0.0.0-20200724192619-8789164de4e6 h1:Hu2VUvmSnZIixFBSf4z9RF4SdMqRQhBKsi9bIIVgw6I=
 github.com/stellar/go v0.0.0-20200727191906-0c67d3ec726a h1:sc4m/GFRsalhKgM5eK2JWTicnD3E+Ife+CFpwGkkGr4=
+github.com/stellar/go v0.0.0-20200727204603-26d14c4f7b90 h1:uvPAihaom5n7YOHgTvXq2s5PSEtnhUm9TMvKsrcz5EY=
 github.com/stellar/go-xdr v0.0.0-20180917104419-0bc96f33a18e h1:n/hfey8pO+RYMoGXyvyzuw5pdO8IFDoyAL/g5OiCesY=
 github.com/stellar/go-xdr v0.0.0-20180917104419-0bc96f33a18e/go.mod h1:gpOLVzy6TVYTQ3LvHSN9RJC700FkhFCpSE82u37aNRM=
+github.com/stellar/go-xdr v0.0.0-20200331223602-71a1e6d555f2 h1:K9H+A+eWe8ZlnpNha+pXbEK+jtIluQp/2dKxkK8k7OE=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=

--- a/internal/transform/operation.go
+++ b/internal/transform/operation.go
@@ -28,10 +28,13 @@ func TransformOperation(operation xdr.Operation, operationIndex int32, transacti
 		return OperationOutput{}, err
 	}
 
+	outputTransactionHash := utils.HashToHexString(transaction.Result.TransactionHash)
+
 	transformedOperation := OperationOutput{
 		SourceAccount:    outputSourceAccount,
 		Type:             outputOperationType,
 		ApplicationOrder: operationIndex + 1, // Application order is 1-indexed
+		TransactionHash:  outputTransactionHash,
 		OperationDetails: outputDetails,
 	}
 

--- a/internal/transform/operation.go
+++ b/internal/transform/operation.go
@@ -29,12 +29,17 @@ func TransformOperation(operation xdr.Operation, operationIndex int32, transacti
 	}
 
 	outputTransactionHash := utils.HashToHexString(transaction.Result.TransactionHash)
+	outputBase64, err := xdr.MarshalBase64(operation)
+	if err != nil {
+		return OperationOutput{}, err
+	}
 
 	transformedOperation := OperationOutput{
 		SourceAccount:    outputSourceAccount,
 		Type:             outputOperationType,
 		ApplicationOrder: operationIndex + 1, // Application order is 1-indexed
 		TransactionHash:  outputTransactionHash,
+		OperationBase64:  outputBase64,
 		OperationDetails: outputDetails,
 	}
 

--- a/internal/transform/operation_test.go
+++ b/internal/transform/operation_test.go
@@ -361,6 +361,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			SourceAccount:    hardCodedSourceAccountAddress,
 			Type:             0,
 			ApplicationOrder: 1,
+			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
 			OperationDetails: Details{
 				Account:         hardCodedDestAccountAddress,
 				Funder:          hardCodedSourceAccountAddress,
@@ -371,7 +372,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			Type:             1,
 			ApplicationOrder: 2,
 			SourceAccount:    hardCodedSourceAccountAddress,
-
+			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
 			OperationDetails: Details{
 				From:        hardCodedSourceAccountAddress,
 				To:          hardCodedDestAccountAddress,
@@ -385,7 +386,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			Type:             1,
 			ApplicationOrder: 3,
 			SourceAccount:    hardCodedSourceAccountAddress,
-
+			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
 			OperationDetails: Details{
 				From:      hardCodedSourceAccountAddress,
 				To:        hardCodedDestAccountAddress,
@@ -397,7 +398,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			Type:             2,
 			ApplicationOrder: 4,
 			SourceAccount:    hardCodedSourceAccountAddress,
-
+			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
 			OperationDetails: Details{
 				From:            hardCodedSourceAccountAddress,
 				To:              hardCodedDestAccountAddress,
@@ -413,6 +414,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			Type:             3,
 			ApplicationOrder: 5,
 			SourceAccount:    hardCodedSourceAccountAddress,
+			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
 			OperationDetails: Details{
 				Price:  0.514092,
 				Amount: 76.586,
@@ -430,6 +432,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			Type:             4,
 			ApplicationOrder: 6,
 			SourceAccount:    hardCodedSourceAccountAddress,
+			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
 			OperationDetails: Details{
 				Amount: 63.1595,
 				Price:  0.0791606,
@@ -447,6 +450,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			Type:             5,
 			ApplicationOrder: 7,
 			SourceAccount:    hardCodedSourceAccountAddress,
+			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
 			OperationDetails: Details{
 				InflationDest:    hardCodedDestAccountAddress,
 				ClearFlags:       []int32{1, 2},
@@ -466,6 +470,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			Type:             6,
 			ApplicationOrder: 8,
 			SourceAccount:    hardCodedSourceAccountAddress,
+			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
 			OperationDetails: Details{
 				Trustor:     hardCodedSourceAccountAddress,
 				Trustee:     hardCodedDestAccountAddress,
@@ -479,6 +484,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			Type:             7,
 			ApplicationOrder: 9,
 			SourceAccount:    hardCodedSourceAccountAddress,
+			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
 			OperationDetails: Details{
 				Trustee:     hardCodedSourceAccountAddress,
 				Trustor:     hardCodedDestAccountAddress,
@@ -492,6 +498,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			Type:             8,
 			ApplicationOrder: 10,
 			SourceAccount:    hardCodedSourceAccountAddress,
+			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
 			OperationDetails: Details{
 				Account: hardCodedSourceAccountAddress,
 				Into:    hardCodedDestAccountAddress,
@@ -501,12 +508,14 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			Type:             9,
 			ApplicationOrder: 11,
 			SourceAccount:    hardCodedSourceAccountAddress,
+			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
 			OperationDetails: Details{},
 		},
 		OperationOutput{
 			Type:             10,
 			ApplicationOrder: 12,
 			SourceAccount:    hardCodedSourceAccountAddress,
+			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
 			OperationDetails: Details{
 				Name:  "test",
 				Value: base64.StdEncoding.EncodeToString([]byte{0x76, 0x61, 0x6c, 0x75, 0x65}),
@@ -516,6 +525,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			Type:             11,
 			ApplicationOrder: 13,
 			SourceAccount:    hardCodedSourceAccountAddress,
+			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
 			OperationDetails: Details{
 				BumpTo: "100",
 			},
@@ -524,6 +534,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			Type:             12,
 			ApplicationOrder: 14,
 			SourceAccount:    hardCodedSourceAccountAddress,
+			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
 			OperationDetails: Details{
 				Price:  0.3496823,
 				Amount: 765.4501001,
@@ -542,6 +553,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			Type:             13,
 			ApplicationOrder: 15,
 			SourceAccount:    hardCodedSourceAccountAddress,
+			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
 			OperationDetails: Details{
 				From:            hardCodedSourceAccountAddress,
 				To:              hardCodedDestAccountAddress,
@@ -557,6 +569,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			Type:             13,
 			ApplicationOrder: 16,
 			SourceAccount:    hardCodedSourceAccountAddress,
+			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
 			OperationDetails: Details{
 				From:            hardCodedSourceAccountAddress,
 				To:              hardCodedDestAccountAddress,

--- a/internal/transform/operation_test.go
+++ b/internal/transform/operation_test.go
@@ -362,6 +362,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			Type:             0,
 			ApplicationOrder: 1,
 			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
+			OperationBase64:  "AAAAAAAAAAAAAAAAa1jdbGiTC20DHcW7+uI++h7D8LtYwryNk41Hwd+zvnMAAAAAAX14QA==",
 			OperationDetails: Details{
 				Account:         hardCodedDestAccountAddress,
 				Funder:          hardCodedSourceAccountAddress,
@@ -373,6 +374,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			ApplicationOrder: 2,
 			SourceAccount:    hardCodedSourceAccountAddress,
 			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
+			OperationBase64:  "AAAAAAAAAAEAAAAAa1jdbGiTC20DHcW7+uI++h7D8LtYwryNk41Hwd+zvnMAAAABVVNEVAAAAABrWN1saJMLbQMdxbv64j76HsPwu1jCvI2TjUfB37O+cwAAAAAU3JOA",
 			OperationDetails: Details{
 				From:        hardCodedSourceAccountAddress,
 				To:          hardCodedDestAccountAddress,
@@ -387,6 +389,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			ApplicationOrder: 3,
 			SourceAccount:    hardCodedSourceAccountAddress,
 			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
+			OperationBase64:  "AAAAAAAAAAEAAAAAa1jdbGiTC20DHcW7+uI++h7D8LtYwryNk41Hwd+zvnMAAAAAAAAAABTck4A=",
 			OperationDetails: Details{
 				From:      hardCodedSourceAccountAddress,
 				To:        hardCodedDestAccountAddress,
@@ -399,6 +402,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			ApplicationOrder: 4,
 			SourceAccount:    hardCodedSourceAccountAddress,
 			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
+			OperationBase64:  "AAAAAQAAAABnzACGTDuJFoxqr+C8NHCe0CHFBXLi+YhhNCIILCIpcgAAAAIAAAAAAAAAAhWM/NwAAAAAa1jdbGiTC20DHcW7+uI++h7D8LtYwryNk41Hwd+zvnMAAAAAAAAAAhWM/NwAAAABAAAAAVVTRFQAAAAAa1jdbGiTC20DHcW7+uI++h7D8LtYwryNk41Hwd+zvnM=",
 			OperationDetails: Details{
 				From:            hardCodedSourceAccountAddress,
 				To:              hardCodedDestAccountAddress,
@@ -415,6 +419,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			ApplicationOrder: 5,
 			SourceAccount:    hardCodedSourceAccountAddress,
 			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
+			OperationBase64:  "AAAAAAAAAAMAAAABVVNEVAAAAABrWN1saJMLbQMdxbv64j76HsPwu1jCvI2TjUfB37O+cwAAAAAAAAAALaYYoAAB9gsAA9CQAAAAAAAAAAA=",
 			OperationDetails: Details{
 				Price:  0.514092,
 				Amount: 76.586,
@@ -433,6 +438,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			ApplicationOrder: 6,
 			SourceAccount:    hardCodedSourceAccountAddress,
 			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
+			OperationBase64:  "AAAAAAAAAAQAAAAAAAAAAVVTRFQAAAAAa1jdbGiTC20DHcW7+uI++h7D8LtYwryNk41Hwd+zvnMAAAAAJaVf+AXvhOBK+2dw",
 			OperationDetails: Details{
 				Amount: 63.1595,
 				Price:  0.0791606,
@@ -451,6 +457,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			ApplicationOrder: 7,
 			SourceAccount:    hardCodedSourceAccountAddress,
 			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
+			OperationBase64:  "AAAAAAAAAAUAAAABAAAAAGtY3WxokwttAx3Fu/riPvoew/C7WMK8jZONR8Hfs75zAAAAAQAAAAMAAAABAAAABAAAAAEAAAADAAAAAQAAAAEAAAABAAAAAwAAAAEAAAAFAAAAAQAAAA8yMDE5PURSQTtuLXRlc3QAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE=",
 			OperationDetails: Details{
 				InflationDest:    hardCodedDestAccountAddress,
 				ClearFlags:       []int32{1, 2},
@@ -471,6 +478,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			ApplicationOrder: 8,
 			SourceAccount:    hardCodedSourceAccountAddress,
 			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
+			OperationBase64:  "AAAAAAAAAAYAAAABVVNEVAAAAABrWN1saJMLbQMdxbv64j76HsPwu1jCvI2TjUfB37O+cwbwW1nTsgAA",
 			OperationDetails: Details{
 				Trustor:     hardCodedSourceAccountAddress,
 				Trustee:     hardCodedDestAccountAddress,
@@ -485,6 +493,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			ApplicationOrder: 9,
 			SourceAccount:    hardCodedSourceAccountAddress,
 			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
+			OperationBase64:  "AAAAAAAAAAcAAAAAa1jdbGiTC20DHcW7+uI++h7D8LtYwryNk41Hwd+zvnMAAAABVVNEVAAAAAE=",
 			OperationDetails: Details{
 				Trustee:     hardCodedSourceAccountAddress,
 				Trustor:     hardCodedDestAccountAddress,
@@ -499,6 +508,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			ApplicationOrder: 10,
 			SourceAccount:    hardCodedSourceAccountAddress,
 			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
+			OperationBase64:  "AAAAAAAAAAgAAAAAa1jdbGiTC20DHcW7+uI++h7D8LtYwryNk41Hwd+zvnM=",
 			OperationDetails: Details{
 				Account: hardCodedSourceAccountAddress,
 				Into:    hardCodedDestAccountAddress,
@@ -509,6 +519,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			ApplicationOrder: 11,
 			SourceAccount:    hardCodedSourceAccountAddress,
 			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
+			OperationBase64:  "AAAAAAAAAAk=",
 			OperationDetails: Details{},
 		},
 		OperationOutput{
@@ -516,6 +527,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			ApplicationOrder: 12,
 			SourceAccount:    hardCodedSourceAccountAddress,
 			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
+			OperationBase64:  "AAAAAAAAAAoAAAAEdGVzdAAAAAEAAAAFdmFsdWUAAAA=",
 			OperationDetails: Details{
 				Name:  "test",
 				Value: base64.StdEncoding.EncodeToString([]byte{0x76, 0x61, 0x6c, 0x75, 0x65}),
@@ -526,6 +538,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			ApplicationOrder: 13,
 			SourceAccount:    hardCodedSourceAccountAddress,
 			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
+			OperationBase64:  "AAAAAAAAAAsAAAAAAAAAZA==",
 			OperationDetails: Details{
 				BumpTo: "100",
 			},
@@ -535,6 +548,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			ApplicationOrder: 14,
 			SourceAccount:    hardCodedSourceAccountAddress,
 			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
+			OperationBase64:  "AAAAAAAAAAwAAAABVVNEVAAAAABrWN1saJMLbQMdxbv64j76HsPwu1jCvI2TjUfB37O+cwAAAAAAAAAByD5qiSXmgPVsYqABAAAAAAAAAGQ=",
 			OperationDetails: Details{
 				Price:  0.3496823,
 				Amount: 765.4501001,
@@ -554,6 +568,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			ApplicationOrder: 15,
 			SourceAccount:    hardCodedSourceAccountAddress,
 			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
+			OperationBase64:  "AAAAAAAAAA0AAAAAAAAAAAAYYuYAAAAAa1jdbGiTC20DHcW7+uI++h7D8LtYwryNk41Hwd+zvnMAAAAAAAAAAP8ipPoAAAABAAAAAVVTRFQAAAAAa1jdbGiTC20DHcW7+uI++h7D8LtYwryNk41Hwd+zvnM=",
 			OperationDetails: Details{
 				From:            hardCodedSourceAccountAddress,
 				To:              hardCodedDestAccountAddress,
@@ -570,6 +585,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			ApplicationOrder: 16,
 			SourceAccount:    hardCodedSourceAccountAddress,
 			TransactionHash:  "0000000000000000000000000000000000000000000000000000000000000000",
+			OperationBase64:  "AAAAAAAAAA0AAAAAAAAAAAAYYuYAAAAAa1jdbGiTC20DHcW7+uI++h7D8LtYwryNk41Hwd+zvnMAAAAAAAAAAP8ipPoAAAAA",
 			OperationDetails: Details{
 				From:            hardCodedSourceAccountAddress,
 				To:              hardCodedDestAccountAddress,

--- a/internal/transform/schema.go
+++ b/internal/transform/schema.go
@@ -76,10 +76,11 @@ type OperationOutput struct {
 	SourceAccount    string  `json:"source_account"`
 	Type             int32   `json:"type"`
 	ApplicationOrder int32   `json:"application_order"`
+	TransactionHash  string  `json:"transaction_id"`
 	OperationDetails Details `json:"details"`
 	/*
 		TODO implement
-			TransactionID int64 // history table mapping that connect operations to their parent transaction
+			TransactionID int64 // history table mapping that connect operations to their parent transaction; will replace hash
 			OperationId int64 // use horizon's toid package
 	*/
 }

--- a/internal/transform/schema.go
+++ b/internal/transform/schema.go
@@ -77,11 +77,12 @@ type OperationOutput struct {
 	Type             int32   `json:"type"`
 	ApplicationOrder int32   `json:"application_order"`
 	TransactionHash  string  `json:"transaction_id"`
+	OperationBase64  string  `json:"id"`
 	OperationDetails Details `json:"details"`
 	/*
 		TODO implement
-			TransactionID int64 // history table mapping that connect operations to their parent transaction; will replace hash
-			OperationId int64 // use horizon's toid package
+			TransactionID int64 // history table mapping that connect operations to their parent transaction; will replace TransactionHash
+			OperationId int64 // use horizon's toid package; replace OperationBase64 with this
 	*/
 }
 
@@ -182,33 +183,36 @@ type OfferOutput struct {
 
 // TradeOutput is a representation of a trade that aligns with the BigQuery table history_trades
 type TradeOutput struct {
-	Order                 int32     `json:"order"`
-	LedgerClosedAt        time.Time `json:"ledger_closed_at"`
-	OfferID               int64     `json:"offer_id"`
-	BaseAccountAddress    string    `json:"base_account_address"`
-	BaseAssetCode         string    `json:"base_asset_code"`
-	BaseAssetIssuer       string    `json:"base_asset_issuer"`
-	BaseAssetType         string    `json:"base_asset_type"`
-	BaseAmount            int64     `json:"base_amount"`
-	CounterAccountAddress string    `json:"counter_account_address"`
-	CounterAssetCode      string    `json:"counter_asset_code"`
-	CounterAssetIssuer    string    `json:"counter_asset_issuer"`
-	CounterAssetType      string    `json:"counter_asset_type"`
-	CounterAmount         int64     `json:"counter_amount"`
-	BaseIsSeller          bool      `json:"base_is_seller"`
-	PriceN                int64     `json:"price_n"`
-	PriceD                int64     `json:"price_d"`
+	Order                  int32     `json:"order"`
+	LedgerClosedAt         time.Time `json:"ledger_closed_at"`
+	OfferID                int64     `json:"offer_id"`
+	BaseAccountAddress     string    `json:"base_account_address"`
+	BaseAssetCode          string    `json:"base_asset_code"`
+	BaseAssetIssuer        string    `json:"base_asset_issuer"`
+	BaseAssetType          string    `json:"base_asset_type"`
+	BaseAmount             int64     `json:"base_amount"`
+	CounterAccountAddress  string    `json:"counter_account_address"`
+	CounterAssetCode       string    `json:"counter_asset_code"`
+	CounterAssetIssuer     string    `json:"counter_asset_issuer"`
+	CounterAssetType       string    `json:"counter_asset_type"`
+	CounterAmount          int64     `json:"counter_amount"`
+	BaseIsSeller           bool      `json:"base_is_seller"`
+	PriceN                 int64     `json:"price_n"`
+	PriceD                 int64     `json:"price_d"`
+	HistoryOperationBase64 string    `json:"history_operation_id"`
 	/*
-		TODO: Figure out how to get base and counter offer id
-			BaseOfferID           int64     `json:"base_offer_id"`
-			CounterOfferID        int64     `json:"counter_offer_id"`
+		TODO:
+			Figure out how to get base and counter offer id
+				BaseOfferID           int64     `json:"base_offer_id"`
+				CounterOfferID        int64     `json:"counter_offer_id"`
 
-			BaseOfferID is the same as the OfferID
-			CounterOfferID:
-				if entry.BuyOfferExists {
-						buyOfferID = EncodeOfferId(uint64(entry.BuyOfferID), CoreOfferIDType)
-					} else {
-						buyOfferID = EncodeOfferId(uint64(entry.HistoryOperationID), TOIDType)
-				}
+				BaseOfferID is the same as the OfferID
+				CounterOfferID:
+					if entry.BuyOfferExists {
+							buyOfferID = EncodeOfferId(uint64(entry.BuyOfferID), CoreOfferIDType)
+						} else {
+							buyOfferID = EncodeOfferId(uint64(entry.HistoryOperationID), TOIDType)
+					}
+			Replace HistoryOperationBase64 with a numeric id that uses horizon's toid package
 	*/
 }

--- a/internal/transform/schema.go
+++ b/internal/transform/schema.go
@@ -2,18 +2,18 @@ package transform
 
 import "time"
 
-//LedgerOutput is a representation of a ledger that aligns with the BigQuery table history_ledgers
+// LedgerOutput is a representation of a ledger that aligns with the BigQuery table history_ledgers
 type LedgerOutput struct {
-	Sequence                   uint32    `json:"sequence"` //sequence number of the ledger
+	Sequence                   uint32    `json:"sequence"` // sequence number of the ledger
 	LedgerHash                 string    `json:"ledger_hash"`
 	PreviousLedgerHash         string    `json:"previous_ledger_hash"`
-	LedgerHeader               []byte    `json:"ledger_header"` //base 64 encoding of the ledger header
+	LedgerHeader               []byte    `json:"ledger_header"` // base 64 encoding of the ledger header
 	TransactionCount           int32     `json:"transaction_count"`
-	OperationCount             int32     `json:"operation_count"` //counts only operations that were a part of successful transactions
+	OperationCount             int32     `json:"operation_count"` // counts only operations that were a part of successful transactions
 	SuccessfulTransactionCount int32     `json:"successful_transaction_count"`
 	FailedTransactionCount     int32     `json:"failed_transaction_count"`
-	TxSetOperationCount        string    `json:"tx_set_operation_count"` //counts all operations, even those that are part of failed transactions
-	ClosedAt                   time.Time `json:"closed_at"`              //UTC timestamp
+	TxSetOperationCount        string    `json:"tx_set_operation_count"` // counts all operations, even those that are part of failed transactions
+	ClosedAt                   time.Time `json:"closed_at"`              // UTC timestamp
 	TotalCoins                 int64     `json:"total_coins"`
 	FeePool                    int64     `json:"fee_pool"`
 	BaseFee                    uint32    `json:"base_fee"`
@@ -22,14 +22,15 @@ type LedgerOutput struct {
 	ProtocolVersion            uint32    `json:"protocol_version"`
 
 	/*
-		TODO implement these three fields
-			CreatedAt time.Time //timestamp of table entry creation time
-			UpdatedAt time.Time //timestamp of table entry update time
-			ImporterVersion int32 //version of the ingestion system
+		TODO implement these four fields
+			CreatedAt time.Time // timestamp of table entry creation time
+			UpdatedAt time.Time // timestamp of table entry update time
+			ImporterVersion int32 // version of the ingestion system
+			LedgerID int64 // use horizon's toid package
 	*/
 }
 
-//TransactionOutput is a representation of a transaction that aligns with the BigQuery table history_transactions
+// TransactionOutput is a representation of a transaction that aligns with the BigQuery table history_transactions
 type TransactionOutput struct {
 	TransactionHash  string    `json:"transaction_hash"`
 	LedgerSequence   uint32    `json:"ledger_sequence"`
@@ -47,13 +48,14 @@ type TransactionOutput struct {
 
 	/*
 		TODO implement
-			updated_at time.Time //timestamp of table entry update time
+			updated_at time.Time // timestamp of table entry update time
+			TransactionID int64 // use horizon's toid package
 	*/
 }
 
-//AccountOutput is a representation of an account that aligns with the BigQuery table accounts
+// AccountOutput is a representation of an account that aligns with the BigQuery table accounts
 type AccountOutput struct {
-	AccountID            string `json:"account_id"`
+	AccountID            string `json:"account_id"` // account address
 	Balance              int64  `json:"balance"`
 	BuyingLiabilities    int64  `json:"buying_liabilities"`
 	SellingLiabilities   int64  `json:"selling_liabilities"`
@@ -69,7 +71,7 @@ type AccountOutput struct {
 	LastModifiedLedger   uint32 `json:"Last_modified_ledger"`
 }
 
-//OperationOutput is a representation of an operation that aligns with the BigQuery table history_operations
+// OperationOutput is a representation of an operation that aligns with the BigQuery table history_operations
 type OperationOutput struct {
 	SourceAccount    string  `json:"source_account"`
 	Type             int32   `json:"type"`
@@ -78,10 +80,11 @@ type OperationOutput struct {
 	/*
 		TODO implement
 			TransactionID int64 // history table mapping that connect operations to their parent transaction
+			OperationId int64 // use horizon's toid package
 	*/
 }
 
-//Details is a struct that provides additional information about operations in a way that aligns with the details struct in the BigQuery table history_operations
+// Details is a struct that provides additional information about operations in a way that aligns with the details struct in the BigQuery table history_operations
 type Details struct {
 	Account            string        `json:"account"`
 	Amount             float64       `json:"amount"`
@@ -123,27 +126,27 @@ type Details struct {
 	To                 string        `json:"to"`
 	Trustee            string        `json:"trustee"`
 	Trustor            string        `json:"trustor"`
-	Value              string        `json:"value"` //base64 encoding of bytes
+	Value              string        `json:"value"` // base64 encoding of bytes
 	ClearFlags         []int32       `json:"clear_flags"`
 	ClearFlagsString   []string      `json:"clear_flags_s"`
 	DestinationMin     string        `json:"destination_min"`
 	BumpTo             string        `json:"bump_to"`
 }
 
-//Price represents the price of an asset as a fraction
+// Price represents the price of an asset as a fraction
 type Price struct {
 	Numerator   int32 `json:"n"`
 	Denominator int32 `json:"d"`
 }
 
-//AssetOutput is a representation of an asset that aligns with the BigQuery table history_assets
+// AssetOutput is a representation of an asset that aligns with the BigQuery table history_assets
 type AssetOutput struct {
 	AssetCode   string `json:"asset_code"`
 	AssetIssuer string `json:"asset_issuer"`
 	AssetType   string `json:"asset_type"`
 }
 
-//TrustlineOutput is a representation of a trustline that aligns with the BigQuery table trust_lines
+// TrustlineOutput is a representation of a trustline that aligns with the BigQuery table trust_lines
 type TrustlineOutput struct {
 	LedgerKey          string `json:"ledger_key"`
 	AccountID          string `json:"account_id"`
@@ -158,7 +161,7 @@ type TrustlineOutput struct {
 	LastModifiedLedger uint32 `json:"Last_modified_ledger"`
 }
 
-//OfferOutput is a representation of an offer that aligns with the BigQuery table offers
+// OfferOutput is a representation of an offer that aligns with the BigQuery table offers
 type OfferOutput struct {
 	SellerID           string  `json:"seller_id"` // Account address of the seller
 	OfferID            int64   `json:"offer_id"`
@@ -176,7 +179,7 @@ type OfferOutput struct {
 	*/
 }
 
-//TradeOutput is a representation of a trade that aligns with the BigQuery table history_trades
+// TradeOutput is a representation of a trade that aligns with the BigQuery table history_trades
 type TradeOutput struct {
 	Order                 int32     `json:"order"`
 	LedgerClosedAt        time.Time `json:"ledger_closed_at"`

--- a/internal/transform/trade.go
+++ b/internal/transform/trade.go
@@ -77,6 +77,7 @@ func TransformTrade(operationIndex int32, transaction ingestio.LedgerTransaction
 		// Final price should be buy / sell
 		outputPriceN, outputPriceD := outputCounterAmount, outputBaseAmount
 
+		outputOperationBase64, err := xdr.MarshalBase64(operation)
 		if err != nil {
 			return []TradeOutput{}, err
 		}
@@ -84,22 +85,23 @@ func TransformTrade(operationIndex int32, transaction ingestio.LedgerTransaction
 		outputBaseIsSeller := true
 
 		trade := TradeOutput{
-			Order:                 outputOrder,
-			LedgerClosedAt:        outputLedgerClosedAt,
-			OfferID:               outputOfferID,
-			BaseAccountAddress:    outputBaseAccountAddress,
-			BaseAssetType:         outputBaseAssetType,
-			BaseAssetCode:         outputBaseAssetCode,
-			BaseAssetIssuer:       outputBaseAssetIssuer,
-			BaseAmount:            outputBaseAmount,
-			CounterAccountAddress: outputCounterAccountAddress,
-			CounterAssetType:      outputCounterAssetType,
-			CounterAssetCode:      outputCounterAssetCode,
-			CounterAssetIssuer:    outputCounterAssetIssuer,
-			CounterAmount:         outputCounterAmount,
-			BaseIsSeller:          outputBaseIsSeller,
-			PriceN:                outputPriceN,
-			PriceD:                outputPriceD,
+			Order:                  outputOrder,
+			LedgerClosedAt:         outputLedgerClosedAt,
+			OfferID:                outputOfferID,
+			BaseAccountAddress:     outputBaseAccountAddress,
+			BaseAssetType:          outputBaseAssetType,
+			BaseAssetCode:          outputBaseAssetCode,
+			BaseAssetIssuer:        outputBaseAssetIssuer,
+			BaseAmount:             outputBaseAmount,
+			CounterAccountAddress:  outputCounterAccountAddress,
+			CounterAssetType:       outputCounterAssetType,
+			CounterAssetCode:       outputCounterAssetCode,
+			CounterAssetIssuer:     outputCounterAssetIssuer,
+			CounterAmount:          outputCounterAmount,
+			BaseIsSeller:           outputBaseIsSeller,
+			PriceN:                 outputPriceN,
+			PriceD:                 outputPriceD,
+			HistoryOperationBase64: outputOperationBase64,
 		}
 
 		transformedTrades = append(transformedTrades, trade)

--- a/internal/transform/trade_test.go
+++ b/internal/transform/trade_test.go
@@ -247,15 +247,19 @@ func makeTradeTestInput() (inputTransaction ingestio.LedgerTransaction) {
 		xdr.Operation{
 			SourceAccount: nil,
 			Body: xdr.OperationBody{
-				Type:                    xdr.OperationTypePathPaymentStrictSend,
-				PathPaymentStrictSendOp: &xdr.PathPaymentStrictSendOp{},
+				Type: xdr.OperationTypePathPaymentStrictSend,
+				PathPaymentStrictSendOp: &xdr.PathPaymentStrictSendOp{
+					Destination: testAccount1,
+				},
 			},
 		},
 		xdr.Operation{
 			SourceAccount: &testAccount3,
 			Body: xdr.OperationBody{
-				Type:                       xdr.OperationTypePathPaymentStrictReceive,
-				PathPaymentStrictReceiveOp: &xdr.PathPaymentStrictReceiveOp{},
+				Type: xdr.OperationTypePathPaymentStrictReceive,
+				PathPaymentStrictReceiveOp: &xdr.PathPaymentStrictReceiveOp{
+					Destination: testAccount1,
+				},
 			},
 		},
 		xdr.Operation{
@@ -393,11 +397,18 @@ func makeTradeTestOutput() [][]TradeOutput {
 	offerTwoOutputSecondPlace := twoPriceIsAmount
 	offerTwoOutputSecondPlace.Order = 1
 
-	return [][]TradeOutput{
+	output := [][]TradeOutput{
 		[]TradeOutput{offerOneOutput},
 		[]TradeOutput{offerTwoOutput},
 		[]TradeOutput{onePriceIsAmount, offerTwoOutputSecondPlace},
 		[]TradeOutput{twoPriceIsAmount, offerOneOutputSecondPlace},
 		[]TradeOutput{},
 	}
+	output[0][0].HistoryOperationBase64 = "AAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+	output[1][0].HistoryOperationBase64 = "AAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+	output[2][0].HistoryOperationBase64 = "AAAAAAAAAA0AAAAAAAAAAAAAAAAAAAAAiOGmtKVxUo+qnybiDmy8P+c8roC0RmMMW+8BUq9wfXgAAAAAAAAAAAAAAAAAAAAA"
+	output[2][1].HistoryOperationBase64 = "AAAAAAAAAA0AAAAAAAAAAAAAAAAAAAAAiOGmtKVxUo+qnybiDmy8P+c8roC0RmMMW+8BUq9wfXgAAAAAAAAAAAAAAAAAAAAA"
+	output[3][0].HistoryOperationBase64 = "AAAAAQAAAABnzACGTDuJFoxqr+C8NHCe0CHFBXLi+YhhNCIILCIpcgAAAAIAAAAAAAAAAAAAAAAAAAAAiOGmtKVxUo+qnybiDmy8P+c8roC0RmMMW+8BUq9wfXgAAAAAAAAAAAAAAAAAAAAA"
+	output[3][1].HistoryOperationBase64 = "AAAAAQAAAABnzACGTDuJFoxqr+C8NHCe0CHFBXLi+YhhNCIILCIpcgAAAAIAAAAAAAAAAAAAAAAAAAAAiOGmtKVxUo+qnybiDmy8P+c8roC0RmMMW+8BUq9wfXgAAAAAAAAAAAAAAAAAAAAA"
+	return output
 }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What
This PR implements alternative ids for various data structures. Hashes are used for transactions, base 64 encoding is used for operations, address is used for accounts, and code, issuer and type are used for assets. Closes #65.

### Why
Since we currently can't access the code that the horizon team uses to generate ids, we need an alternative for v1 of the ETL. These replacements connects things like operations and transactions or trades and operations without using the inaccessible id.

### Known limitations
Ideally, we would be able to use the true horizon ids in the future. There are TODO comments where we would eventually substitute these ids.