### PR TITLE
stellar-etl: goroutine and channels for ledger changes export

### DIFF
--- a/cmd/export_ledger_entry_changes.go
+++ b/cmd/export_ledger_entry_changes.go
@@ -64,7 +64,6 @@ be exported.`,
 
 			select {
 			case entry, ok := <-accChannel:
-				fmt.Println(entry, ok)
 				if !ok {
 					accChannel = nil
 				} else {
@@ -77,7 +76,6 @@ be exported.`,
 				}
 
 			case entry, ok := <-offChannel:
-				fmt.Println(entry, ok)
 				wrappedEntry := ingestio.Change{Type: xdr.LedgerEntryTypeOffer, Post: &entry}
 				offer, err := transform.TransformOffer(wrappedEntry)
 				if !ok {
@@ -91,7 +89,6 @@ be exported.`,
 				}
 
 			case entry, ok := <-trustChannel:
-				fmt.Println(entry, ok)
 				trust, err := transform.TransformTrustline(entry)
 				if !ok {
 					trustChannel = nil

--- a/cmd/export_ledger_entry_changes_test.go
+++ b/cmd/export_ledger_entry_changes_test.go
@@ -3,11 +3,13 @@ package cmd
 import "testing"
 
 func TestExportChanges(t *testing.T) {
+	coreExecutablePath := "../stellar-core/src/stellar-core"
+	coreConfigPath := "../stellar-core/docs/stellar-core_example.cfg"
 	tests := []cliTest{
 		{
-			name:    "small range",
-			args:    []string{"export_ledger_entry_changes", "-x", "../stellar-core/src/stellar-core -c", "../stellar-core/docs/stellar-core_example.cfg", "-s", "100", "-e", "101"},
-			golden:  "bucket_read_exact.golden",
+			name:    "single ledger",
+			args:    []string{"export_ledger_entry_changes", "-x", coreExecutablePath, "-c", coreConfigPath, "-s", "100", "-e", "100", "--stdout"},
+			golden:  "single_ledger.golden",
 			wantErr: nil,
 		},
 	}

--- a/cmd/export_ledger_entry_changes_test.go
+++ b/cmd/export_ledger_entry_changes_test.go
@@ -1,0 +1,18 @@
+package cmd
+
+import "testing"
+
+func TestExportChanges(t *testing.T) {
+	tests := []cliTest{
+		{
+			name:    "small range",
+			args:    []string{"export_ledger_entry_changes", "-x", "../stellar-core/src/stellar-core -c", "../stellar-core/docs/stellar-core_example.cfg", "-s", "100", "-e", "101"},
+			golden:  "bucket_read_exact.golden",
+			wantErr: nil,
+		},
+	}
+
+	for _, test := range tests {
+		runCLITest(t, test, "testdata/changes/")
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -327,6 +327,9 @@ github.com/stellar/go v0.0.0-20200730103443-19c3edf06d4a h1:GLvztNbJyWueX3bpCghU
 github.com/stellar/go v0.0.0-20200730205046-43f14b313c04 h1:zV+1ikhd5ahMGPYYHVgp7yXR+lEdl+MjQYnsyxhFQnI=
 github.com/stellar/go v0.0.0-20200804130752-fdc4eca4f6ce h1:Lixum59yJNsfxgKO1e99ZwWKgfmQfFWRD5U4oyFxazc=
 github.com/stellar/go v0.0.0-20200804130752-fdc4eca4f6ce/go.mod h1:LDU2cdYFQbYGt7UtgciOw8g5DXdc93r6N3e1mdHWems=
+github.com/stellar/go v0.0.0-20200810222602-1f30d278b6e4 h1:vC9Xnb3w0zT7AXtEnhsNU77tt1rQ/5JK8UKsRqesXlw=
+github.com/stellar/go v0.0.0-20200811160423-742703c04ccd h1:0lqyvtgn0ePucq0iUKclfFM2UktqMQ4df6+SUjlvUyE=
+github.com/stellar/go v0.0.0-20200811193520-5215f1ee039b h1:CNK9fAO8CqIXJCNhwZXoHet7XkHCnPgJsGaSA9otb0I=
 github.com/stellar/go-xdr v0.0.0-20200331223602-71a1e6d555f2 h1:K9H+A+eWe8ZlnpNha+pXbEK+jtIluQp/2dKxkK8k7OE=
 github.com/stellar/go-xdr v0.0.0-20200331223602-71a1e6d555f2/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=

--- a/internal/input/changes.go
+++ b/internal/input/changes.go
@@ -59,6 +59,7 @@ func PrepareCaptiveCore(execPath, configPath string, start, end uint32) (*ledger
 	return captiveBackend, nil
 }
 
+// getCompactedChanges compacts the read changes from a ledger and returns them
 func getCompactedChanges(changeReader *ingestio.LedgerChangeReader) []ingestio.Change {
 	changeCache := ingestio.NewLedgerEntryChangeCache()
 	for {
@@ -75,6 +76,7 @@ func getCompactedChanges(changeReader *ingestio.LedgerChangeReader) []ingestio.C
 	return changeCache.GetChanges()
 }
 
+// sendToChannel sends a ledgerentry to the appropriate channel, checking that the channel is not nil before sending
 func sendToChannel(entry xdr.LedgerEntry, accChannel, offChannel, trustChannel chan xdr.LedgerEntry) {
 	switch entry.Data.Type {
 	case xdr.LedgerEntryTypeAccount:
@@ -95,6 +97,7 @@ func sendToChannel(entry xdr.LedgerEntry, accChannel, offChannel, trustChannel c
 	}
 }
 
+// closeChannels checks that the provided channels are not nil, and then closes them
 func closeChannels(accChannel, offChannel, trustChannel chan xdr.LedgerEntry) {
 	if accChannel != nil {
 		close(accChannel)
@@ -109,40 +112,36 @@ func closeChannels(accChannel, offChannel, trustChannel chan xdr.LedgerEntry) {
 	}
 }
 
-// StreamChanges reads in ledgers, processes the changes, and send the changes to the channel matching their type
-func StreamChanges(core *ledgerbackend.CaptiveStellarCore, start, end uint32, accChannel, offChannel, trustChannel chan xdr.LedgerEntry) {
-	if end != 0 {
-		for seq := start; seq <= end; seq++ {
-			changeReader, err := ingestio.NewLedgerChangeReader(core, network.PublicNetworkPassphrase, seq)
-			if err == nil {
-				compactedChanges := getCompactedChanges(changeReader)
-				for _, change := range compactedChanges {
-					// TODO: figure out how to handle deleted entries
-					if change.Post != nil {
-						entry := *change.Post
-						sendToChannel(entry, accChannel, offChannel, trustChannel)
-					}
-				}
-			}
-		}
-	} else {
-		currentLedger := start
-		for {
-			changeReader, err := ingestio.NewLedgerChangeReader(core, network.PublicNetworkPassphrase, currentLedger)
-			if err == nil {
-				compactedChanges := getCompactedChanges(changeReader)
-				for _, change := range compactedChanges {
-					// TODO: figure out how to handle deleted entries
-					if change.Post != nil {
-						entry := *change.Post
-						sendToChannel(entry, accChannel, offChannel, trustChannel)
-					}
-				}
-
-				currentLedger++
+// sendLedgerChangesToChannels streams the changes from a single ledger to the provided channels
+func sendLedgerChangesToChannels(seqNum uint32, core *ledgerbackend.CaptiveStellarCore, accChannel, offChannel, trustChannel chan xdr.LedgerEntry) {
+	changeReader, err := ingestio.NewLedgerChangeReader(core, network.PublicNetworkPassphrase, seqNum)
+	if err == nil {
+		compactedChanges := getCompactedChanges(changeReader)
+		for _, change := range compactedChanges {
+			// TODO: figure out how to handle deleted entries
+			if change.Post != nil {
+				entry := *change.Post
+				sendToChannel(entry, accChannel, offChannel, trustChannel)
 			}
 		}
 	}
+}
 
-	closeChannels(accChannel, offChannel, trustChannel)
+// StreamChanges runs a goroutine that reads in ledgers, processes the changes, and send the changes to the channel matching their type
+func StreamChanges(core *ledgerbackend.CaptiveStellarCore, start, end uint32, accChannel, offChannel, trustChannel chan xdr.LedgerEntry) {
+	go func() {
+		if end != 0 {
+			for seq := start; seq <= end; seq++ {
+				sendLedgerChangesToChannels(seq, core, accChannel, offChannel, trustChannel)
+			}
+		} else {
+			currentLedger := start
+			for {
+				sendLedgerChangesToChannels(currentLedger, core, accChannel, offChannel, trustChannel)
+				currentLedger++
+			}
+		}
+
+		closeChannels(accChannel, offChannel, trustChannel)
+	}()
 }

--- a/internal/input/changes.go
+++ b/internal/input/changes.go
@@ -1,0 +1,148 @@
+package input
+
+import (
+	ingestio "github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/exp/ingest/ledgerbackend"
+	"github.com/stellar/go/network"
+	"github.com/stellar/go/xdr"
+	"github.com/stellar/stellar-etl/internal/utils"
+)
+
+func getLatestLedgerNumber() (uint32, error) {
+	backend, err := utils.CreateBackend()
+	if err != nil {
+		return 0, err
+	}
+
+	defer backend.Close()
+
+	latestNum, err := backend.GetLatestLedgerSequence()
+	if err != nil {
+		return 0, err
+	}
+
+	return latestNum, nil
+}
+
+// PrepareCaptiveCore creates a new captive core instance and prepares it with the given range. The range is unbounded when end = 0, and is bounded and validated otherwise
+func PrepareCaptiveCore(execPath, configPath string, start, end uint32) (*ledgerbackend.CaptiveStellarCore, error) {
+	captiveBackend, err := ledgerbackend.NewCaptive(
+		execPath,
+		configPath,
+		network.PublicNetworkPassphrase,
+		[]string{archiveStellarURL},
+	)
+	if err != nil {
+		return &ledgerbackend.CaptiveStellarCore{}, err
+	}
+
+	ledgerRange := ledgerbackend.UnboundedRange(start)
+
+	if end != 0 {
+		ledgerRange = ledgerbackend.BoundedRange(start, end)
+		latest, err := getLatestLedgerNumber()
+		if err != nil {
+			return &ledgerbackend.CaptiveStellarCore{}, err
+		}
+
+		err = validateLedgerRange(start, end, latest)
+		if err != nil {
+			return &ledgerbackend.CaptiveStellarCore{}, err
+		}
+	}
+
+	err = captiveBackend.PrepareRange(ledgerRange)
+	if err != nil {
+		return &ledgerbackend.CaptiveStellarCore{}, err
+	}
+
+	return captiveBackend, nil
+}
+
+func getCompactedChanges(changeReader *ingestio.LedgerChangeReader) []ingestio.Change {
+	changeCache := ingestio.NewLedgerEntryChangeCache()
+	for {
+		change, err := changeReader.Read()
+		if err == ingestio.EOF {
+			break
+		}
+
+		if err == nil {
+			changeCache.AddChange(change)
+		}
+	}
+
+	return changeCache.GetChanges()
+}
+
+func sendToChannel(entry xdr.LedgerEntry, accChannel, offChannel, trustChannel chan xdr.LedgerEntry) {
+	switch entry.Data.Type {
+	case xdr.LedgerEntryTypeAccount:
+		if accChannel != nil {
+			accChannel <- entry
+		}
+
+	case xdr.LedgerEntryTypeOffer:
+		if offChannel != nil {
+			offChannel <- entry
+		}
+
+	case xdr.LedgerEntryTypeTrustline:
+		if trustChannel != nil {
+			trustChannel <- entry
+		}
+
+	}
+}
+
+func closeChannels(accChannel, offChannel, trustChannel chan xdr.LedgerEntry) {
+	if accChannel != nil {
+		close(accChannel)
+	}
+
+	if offChannel != nil {
+		close(offChannel)
+	}
+
+	if trustChannel != nil {
+		close(trustChannel)
+	}
+}
+
+// StreamChanges reads in ledgers, processes the changes, and send the changes to the channel matching their type
+func StreamChanges(core *ledgerbackend.CaptiveStellarCore, start, end uint32, accChannel, offChannel, trustChannel chan xdr.LedgerEntry) {
+	if end != 0 {
+		for seq := start; seq <= end; seq++ {
+			changeReader, err := ingestio.NewLedgerChangeReader(core, network.PublicNetworkPassphrase, seq)
+			if err == nil {
+				compactedChanges := getCompactedChanges(changeReader)
+				for _, change := range compactedChanges {
+					// TODO: figure out how to handle deleted entries
+					if change.Post != nil {
+						entry := *change.Post
+						sendToChannel(entry, accChannel, offChannel, trustChannel)
+					}
+				}
+			}
+		}
+	} else {
+		currentLedger := start
+		for {
+			changeReader, err := ingestio.NewLedgerChangeReader(core, network.PublicNetworkPassphrase, currentLedger)
+			if err == nil {
+				compactedChanges := getCompactedChanges(changeReader)
+				for _, change := range compactedChanges {
+					// TODO: figure out how to handle deleted entries
+					if change.Post != nil {
+						entry := *change.Post
+						sendToChannel(entry, accChannel, offChannel, trustChannel)
+					}
+				}
+
+				currentLedger++
+			}
+		}
+	}
+
+	closeChannels(accChannel, offChannel, trustChannel)
+}

--- a/internal/input/changes_test.go
+++ b/internal/input/changes_test.go
@@ -1,0 +1,97 @@
+package input
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stellar/go/xdr"
+)
+
+func TestSendToChannel(t *testing.T) {
+	type functionInput struct {
+		entry        xdr.LedgerEntry
+		accChannel   chan xdr.LedgerEntry
+		offChannel   chan xdr.LedgerEntry
+		trustChannel chan xdr.LedgerEntry
+	}
+	type functionOutput struct {
+		accEntry   xdr.LedgerEntry
+		offEntry   xdr.LedgerEntry
+		trustEntry xdr.LedgerEntry
+	}
+
+	acc := make(chan xdr.LedgerEntry)
+	off := make(chan xdr.LedgerEntry)
+	trust := make(chan xdr.LedgerEntry)
+
+	accountTestEntry := xdr.LedgerEntry{
+		Data: xdr.LedgerEntryData{
+			Type:    xdr.LedgerEntryTypeAccount,
+			Account: &xdr.AccountEntry{},
+		},
+	}
+	offerTestEntry := xdr.LedgerEntry{
+		Data: xdr.LedgerEntryData{
+			Type:  xdr.LedgerEntryTypeOffer,
+			Offer: &xdr.OfferEntry{},
+		},
+	}
+	trustTestEntry := xdr.LedgerEntry{
+		Data: xdr.LedgerEntryData{
+			Type:      xdr.LedgerEntryTypeTrustline,
+			TrustLine: &xdr.TrustLineEntry{},
+		},
+	}
+
+	tests := []struct {
+		name string
+		args functionInput
+		out  functionOutput
+	}{
+		{
+			name: "account",
+			args: functionInput{
+				entry:        accountTestEntry,
+				accChannel:   acc,
+				offChannel:   off,
+				trustChannel: trust,
+			},
+			out: functionOutput{
+				accEntry: accountTestEntry,
+			},
+		},
+		{
+			name: "offer",
+			args: functionInput{
+				entry:        offerTestEntry,
+				accChannel:   acc,
+				offChannel:   off,
+				trustChannel: trust,
+			},
+			out: functionOutput{
+				offEntry: offerTestEntry,
+			},
+		},
+		{
+			name: "trustline",
+			args: functionInput{
+				entry:        trustTestEntry,
+				accChannel:   acc,
+				offChannel:   off,
+				trustChannel: trust,
+			},
+			out: functionOutput{
+				trustEntry: trustTestEntry,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sendToChannel(tt.args.entry, tt.args.accChannel, tt.args.offChannel, tt.args.trustChannel)
+			assert.Equal(t, tt.out.accEntry, <-tt.args.accChannel)
+			assert.Equal(t, tt.out.offEntry, <-tt.args.offChannel)
+			assert.Equal(t, tt.out.trustEntry, <-tt.args.trustChannel)
+		})
+	}
+}

--- a/internal/utils/main.go
+++ b/internal/utils/main.go
@@ -110,10 +110,16 @@ func AddBasicFlags(objectName string, flags *pflag.FlagSet) {
 	flags.Bool("stdout", false, "If set, the output will be printed to stdout instead of to a file")
 }
 
-// AddCoreFlags adds the core-executable and core-config flags, which are needed for commands that use captive core
+// AddCoreFlags adds the core-executable, core-config, batch-size, and export{type} flags, which are needed for commands that use captive core
 func AddCoreFlags(flags *pflag.FlagSet) {
 	flags.StringP("core-executable", "x", "", "Filepath to the stellar-core executable")
 	flags.StringP("core-config", "c", "", "Filepath to the a config file for stellar-core")
+
+	flags.BoolP("export-accounts", "a", false, "set in order to export account changes")
+	flags.BoolP("export-trustlines", "t", false, "set in order to export trustline changes")
+	flags.BoolP("export-offers", "f", false, "set in order to export offer changes")
+
+	flags.Uint32P("batch-size", "b", 64, "number of ledgers to export changes from in each batches")
 }
 
 // AddBucketFlags adds the end-ledger, output, and stdout flags, which are needed for commands that use the bucket list
@@ -153,8 +159,8 @@ func MustBasicFlags(flags *pflag.FlagSet, logger *log.Entry) (startNum, endNum u
 	return
 }
 
-// MustCoreFlags gets the values for the core-executable and core-config flags. If any do not exist, it stops the program fatally using the logger
-func MustCoreFlags(flags *pflag.FlagSet, logger *log.Entry) (execPath, configPath string) {
+// MustCoreFlags gets the values for the core-executable, core-config, batch-size, and export{type} flags. If any do not exist, it stops the program fatally using the logger
+func MustCoreFlags(flags *pflag.FlagSet, logger *log.Entry) (execPath, configPath string, exportAccounts, exportOffers, exportTrustlines bool, batchSize uint32) {
 	execPath, err := flags.GetString("core-executable")
 	if err != nil {
 		logger.Fatal("could not get path to stellar-core executable, which is mandatory when not starting at the genesis ledger (ledger 1): ", err)
@@ -163,6 +169,26 @@ func MustCoreFlags(flags *pflag.FlagSet, logger *log.Entry) (execPath, configPat
 	configPath, err = flags.GetString("core-config")
 	if err != nil {
 		logger.Fatal("could not get path to stellar-core config file, is mandatory when not starting at the genesis ledger (ledger 1): ", err)
+	}
+
+	exportAccounts, err = flags.GetBool("export-accounts")
+	if err != nil {
+		logger.Fatal("could not get export accounts flag: ", err)
+	}
+
+	exportOffers, err = flags.GetBool("export-offers")
+	if err != nil {
+		logger.Fatal("could not get export offers flag: ", err)
+	}
+
+	exportTrustlines, err = flags.GetBool("export-trustlines")
+	if err != nil {
+		logger.Fatal("could not get export trustlines flag: ", err)
+	}
+
+	batchSize, err = flags.GetUint32("batch-size")
+	if err != nil {
+		logger.Fatal("could not get batch size: ", err)
 	}
 
 	return


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What

This PR implements reading data from stellar core and sending it to the correct channel. It also supports reading data from the channels.

### Why

In order to export data that is represented as ledger entries, we need a long running stellar core instance that runs in the background. By setting up these channels, we can access information from the core instance as it appears.

### Known limitations

Entries that are deleted are not represented. In addition, no information is exported yet, its just stored in memory. As a result, some flags are not used.