### PR TITLE
transform: improved trustline error messages

### DIFF
--- a/internal/transform/trustline_test.go
+++ b/internal/transform/trustline_test.go
@@ -33,7 +33,7 @@ func TestTransformTrustline(t *testing.T) {
 				Asset:     nativeAsset,
 				AccountId: genericAccountID,
 			}, 0),
-			TrustlineOutput{}, fmt.Errorf("Balance is negative (-1) for trustline"),
+			TrustlineOutput{}, fmt.Errorf("Balance is negative (-1) for trustline (account is %s and asset is native)", genericAccountAddress),
 		},
 		{
 			wrapTrustlineEntry(xdr.TrustLineEntry{


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What
This PR improves the error messages for trustlines by adding the account and asset. 

### Why
This makes identifying problems when exporting trustlines easier.

### Known limitations
