### PR TITLE
transform: added HistoryOperationID field

### DIFF
--- a/internal/transform/schema.go
+++ b/internal/transform/schema.go
@@ -195,15 +195,5 @@ type TradeOutput struct {
 	PriceD                int64     `json:"price_d"`
 	BaseOfferID           int64     `json:"base_offer_id"`
 	CounterOfferID        int64     `json:"counter_offer_id"`
-	/*
-		TODO:
-				BaseOfferID is the same as the OfferID
-				CounterOfferID:
-					if entry.BuyOfferExists {
-							buyOfferID = EncodeOfferId(uint64(entry.BuyOfferID), CoreOfferIDType)
-						} else {
-							buyOfferID = EncodeOfferId(uint64(entry.HistoryOperationID), TOIDType)
-					}
-			Replace HistoryOperationBase64 with a numeric id that uses horizon's toid package
-	*/
+	HistoryOperationID    int64     `json:"history_operation_id"`
 }

--- a/internal/transform/trade.go
+++ b/internal/transform/trade.go
@@ -23,6 +23,7 @@ func TransformTrade(operationIndex int32, operationID int64, transaction ingesti
 	}
 
 	operation := transaction.Envelope.Operations()[operationIndex]
+	outputOperationID := operationID
 	claimedOffers, counterOffer, err := extractClaimedOffers(operationResults, operationIndex, operation.Body.Type)
 	if err != nil {
 		return []TradeOutput{}, err
@@ -106,6 +107,7 @@ func TransformTrade(operationIndex int32, operationID int64, transaction ingesti
 			PriceD:                outputPriceD,
 			BaseOfferID:           outputOfferID,
 			CounterOfferID:        outputCounterOfferID,
+			HistoryOperationID:    outputOperationID,
 		}
 
 		transformedTrades = append(transformedTrades, trade)

--- a/internal/transform/trade_test.go
+++ b/internal/transform/trade_test.go
@@ -185,7 +185,7 @@ func TestTransformTrade(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		actualOutput, actualError := TransformTrade(test.input.index, 0, test.input.transaction, test.input.closeTime)
+		actualOutput, actualError := TransformTrade(test.input.index, 100, test.input.transaction, test.input.closeTime)
 		assert.Equal(t, test.wantErr, actualError)
 		assert.Equal(t, test.wantOutput, actualOutput)
 	}
@@ -364,7 +364,8 @@ func makeTradeTestOutput() [][]TradeOutput {
 		PriceN:                12634,
 		PriceD:                13300347,
 		BaseOfferID:           97684906,
-		CounterOfferID:        4611686018427387904,
+		CounterOfferID:        4611686018427388004,
+		HistoryOperationID:    100,
 	}
 	offerTwoOutput := TradeOutput{
 		Order:                 0,
@@ -384,7 +385,8 @@ func makeTradeTestOutput() [][]TradeOutput {
 		PriceN:                57798933,
 		PriceD:                17339680,
 		BaseOfferID:           86106895,
-		CounterOfferID:        4611686018427387904,
+		CounterOfferID:        4611686018427388004,
+		HistoryOperationID:    100,
 	}
 
 	onePriceIsAmount := offerOneOutput


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What
This PR adds the history operation id field to trades. Closes #100.

### Why
This field is present in the BigQuery tables, and should be available going forward as well.

### Known limitations