### PR TITLE
cmd: ensure output file permissions are checked

### DIFF
--- a/cmd/export_ledgers.go
+++ b/cmd/export_ledgers.go
@@ -22,7 +22,7 @@ func createOutputFile(filepath string) error {
 
 		defer file.Close()
 	}
-	
+
 	return nil
 }
 
@@ -37,10 +37,9 @@ func mustOutFile(path string) *os.File {
 		cmdLogger.Fatal("could not create output file: ", err)
 	}
 
-	// TODO: check the permissions of the file to ensure that it can be written to
 	outFile, err := os.OpenFile(absolutePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
-		cmdLogger.Fatal("error in output file: ", err)
+		cmdLogger.Fatal("error in opening output file: ", err)
 	}
 
 	return outFile

--- a/go.sum
+++ b/go.sum
@@ -434,6 +434,7 @@ github.com/stellar/go v0.0.0-20200820150558-f57b47851c33 h1:1mLRGXTGK6VPOUih+Pvf
 github.com/stellar/go v0.0.0-20200827221214-3ad0378dd691 h1:3pTQ+sf6/pr+fQdzeTn12lTBGh/1S6+m4v38p2C656U=
 github.com/stellar/go v0.0.0-20200827221214-3ad0378dd691/go.mod h1:PGVMUzNBHfCpregVTwNK1uNTQTgsw9yrZZN53csq5JA=
 github.com/stellar/go v0.0.0-20200831172902-bdde26347d0c h1:b63+ci6Av0CralnPZL0bm1eoPYSuxe69WybVAB/s8Eg=
+github.com/stellar/go v0.0.0-20200914163951-8742d333c65d h1:wD8sI0cW0MzXwXVrWaqID/YrET3d0Ni7A2fBryER0Ig=
 github.com/stellar/go-xdr v0.0.0-20200331223602-71a1e6d555f2 h1:K9H+A+eWe8ZlnpNha+pXbEK+jtIluQp/2dKxkK8k7OE=
 github.com/stellar/go-xdr v0.0.0-20200331223602-71a1e6d555f2/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What
This PR ensures file permissions are checked. Since they were, this involves removing the todo and improving an error message. Closes #86.

### Why
We wanted to make sure that if the program didn't have permissions to create an output file, it would end with a helpful error message.
 
### Known limitations