### PR TITLE
stellar-etl: change transform errors severity

### DIFF
--- a/cmd/export_ledgers.go
+++ b/cmd/export_ledgers.go
@@ -45,12 +45,29 @@ func mustOutFile(path string) *os.File {
 	return outFile
 }
 
+// Prints the number of attempted, failed, and successful transformations as a JSON object
+func printTransformStats(attempts, failures int) {
+	resultsMap := map[string]int{
+		"attempted_transforms":  attempts,
+		"failed_transforms":     failures,
+		"successful_transforms": attempts - failures,
+	}
+
+	results, err := json.Marshal(resultsMap)
+	if err != nil {
+		cmdLogger.Fatal("Could not marshall results: ", err)
+	}
+
+	fmt.Println(string(results))
+}
+
 var ledgersCmd = &cobra.Command{
 	Use:   "export_ledgers",
 	Short: "Exports the ledger data.",
 	Long:  `Exports ledger data within the specified range to an output file. Data is appended to the output file after being encoded as a JSON object.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		startNum, endNum, limit, path, useStdout := utils.MustBasicFlags(cmd.Flags(), cmdLogger)
+		endNum, useStdout, strictExport := utils.MustCommonFlags(cmd.Flags(), cmdLogger)
+		startNum, path, limit := utils.MustArchiveFlags(cmd.Flags(), cmdLogger)
 
 		var outFile *os.File
 		if !useStdout {
@@ -62,15 +79,30 @@ var ledgersCmd = &cobra.Command{
 			cmdLogger.Fatal("could not read ledgers: ", err)
 		}
 
+		failures := 0
 		for i, lcm := range ledgers {
 			transformed, err := transform.TransformLedger(lcm)
 			if err != nil {
-				cmdLogger.Fatal(fmt.Sprintf("could not transform ledger %d: ", startNum+uint32(i)), err)
+				errMsg := fmt.Sprintf("could not transform ledger %d: ", startNum+uint32(i))
+				if strictExport {
+					cmdLogger.Fatal(errMsg, err)
+				} else {
+					cmdLogger.Warning(errMsg, err)
+					failures++
+					continue
+				}
 			}
 
 			marshalled, err := json.Marshal(transformed)
 			if err != nil {
-				cmdLogger.Fatal(fmt.Sprintf("could not json encode ledger %d: ", startNum+uint32(i)), err)
+				errMsg := fmt.Sprintf("could not json encode ledger %d: ", startNum+uint32(i))
+				if strictExport {
+					cmdLogger.Fatal(errMsg, err)
+				} else {
+					cmdLogger.Warning(errMsg, err)
+					failures++
+					continue
+				}
 			}
 
 			if !useStdout {
@@ -80,12 +112,17 @@ var ledgersCmd = &cobra.Command{
 				fmt.Println(string(marshalled))
 			}
 		}
+
+		if !strictExport {
+			printTransformStats(len(ledgers), failures)
+		}
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(ledgersCmd)
-	utils.AddBasicFlags("ledgers", ledgersCmd.Flags())
+	utils.AddCommonFlags(ledgersCmd.Flags())
+	utils.AddArchiveFlags("ledgers", ledgersCmd.Flags())
 	ledgersCmd.MarkFlagRequired("end-ledger")
 	/*
 		Current flags:

--- a/cmd/get_ledger_range_from_times.go
+++ b/cmd/get_ledger_range_from_times.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/stellar/stellar-etl/internal/input"
-	"github.com/stellar/stellar-etl/internal/utils"
 
 	"github.com/spf13/cobra"
 )
@@ -36,7 +35,16 @@ var getLedgerRangeFromTimesCmd = &cobra.Command{
 			cmdLogger.Fatal("could not get end time: ", err)
 		}
 
-		path, useStdout := utils.MustOutputFlags(cmd.Flags(), cmdLogger)
+		path, err := cmd.Flags().GetString("output")
+		if err != nil {
+			cmdLogger.Fatal("could not get output path: ", err)
+		}
+
+		useStdout, err := cmd.Flags().GetBool("stdout")
+		if err != nil {
+			cmdLogger.Fatal("could not get stdout boolean: ", err)
+		}
+
 		var outFile *os.File
 		if !useStdout {
 			outFile = mustOutFile(path)
@@ -75,9 +83,12 @@ var getLedgerRangeFromTimesCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(getLedgerRangeFromTimesCmd)
-	utils.AddOutputFlags("range", getLedgerRangeFromTimesCmd.Flags())
+
 	getLedgerRangeFromTimesCmd.Flags().StringP("start-time", "s", "", "The start time")
 	getLedgerRangeFromTimesCmd.Flags().StringP("end-time", "e", "", "The end time")
+	getLedgerRangeFromTimesCmd.Flags().StringP("output", "o", "exported_range.txt", "Filename of the output file")
+	getLedgerRangeFromTimesCmd.Flags().Bool("stdout", false, "If set, the output will be printed to stdout instead of to a file")
+
 	getLedgerRangeFromTimesCmd.MarkFlagRequired("start-time")
 	getLedgerRangeFromTimesCmd.MarkFlagRequired("end-time")
 }

--- a/go.sum
+++ b/go.sum
@@ -435,6 +435,8 @@ github.com/stellar/go v0.0.0-20200827221214-3ad0378dd691 h1:3pTQ+sf6/pr+fQdzeTn1
 github.com/stellar/go v0.0.0-20200827221214-3ad0378dd691/go.mod h1:PGVMUzNBHfCpregVTwNK1uNTQTgsw9yrZZN53csq5JA=
 github.com/stellar/go v0.0.0-20200831172902-bdde26347d0c h1:b63+ci6Av0CralnPZL0bm1eoPYSuxe69WybVAB/s8Eg=
 github.com/stellar/go v0.0.0-20200914163951-8742d333c65d h1:wD8sI0cW0MzXwXVrWaqID/YrET3d0Ni7A2fBryER0Ig=
+github.com/stellar/go v0.0.0-20200917104244-8dc2a7354bf8 h1:hdrW8jhTrR6bagF4gzfItdiI/xeRv3FjptWco2Toz7I=
+github.com/stellar/go v0.0.0-20200918155524-d6803f9c1eb8 h1:tJGSSsR1zKxHOhHp2KHKQDy3GLmoczB133uR94ea744=
 github.com/stellar/go-xdr v0.0.0-20200331223602-71a1e6d555f2 h1:K9H+A+eWe8ZlnpNha+pXbEK+jtIluQp/2dKxkK8k7OE=
 github.com/stellar/go-xdr v0.0.0-20200331223602-71a1e6d555f2/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=

--- a/internal/input/changes.go
+++ b/internal/input/changes.go
@@ -219,7 +219,7 @@ func StreamChanges(core *ledgerbackend.CaptiveStellarCore, start, end, batchSize
 }
 
 // ReceiveChanges reads in the ledger entries from the provided channels, transforms them, and adds them to the slice with the other transformed entries.
-func ReceiveChanges(accChannel, offChannel, trustChannel chan ChangeBatch, logger *log.Entry) ([]transform.AccountOutput, []transform.OfferOutput, []transform.TrustlineOutput) {
+func ReceiveChanges(accChannel, offChannel, trustChannel chan ChangeBatch, strictExport bool, logger *log.Entry) ([]transform.AccountOutput, []transform.OfferOutput, []transform.TrustlineOutput) {
 	transformedAccounts := make([]transform.AccountOutput, 0)
 	transformedOffers := make([]transform.OfferOutput, 0)
 	transformedTrustlines := make([]transform.TrustlineOutput, 0)
@@ -238,8 +238,12 @@ func ReceiveChanges(accChannel, offChannel, trustChannel chan ChangeBatch, logge
 				if err != nil {
 					entry, _, _ := utils.ExtractEntryFromChange(change)
 					errorMsg := fmt.Sprintf("error transforming account entry last updated at: %d", entry.LastModifiedLedgerSeq)
-					logger.Error(errorMsg, err)
-					break
+					if strictExport {
+						logger.Fatal(errorMsg, err)
+					} else {
+						logger.Warning(errorMsg, err)
+						continue
+					}
 				}
 
 				transformedAccounts = append(transformedAccounts, acc)
@@ -258,8 +262,12 @@ func ReceiveChanges(accChannel, offChannel, trustChannel chan ChangeBatch, logge
 				if err != nil {
 					entry, _, _ := utils.ExtractEntryFromChange(change)
 					errorMsg := fmt.Sprintf("error transforming offer entry last updated at: %d", entry.LastModifiedLedgerSeq)
-					logger.Error(errorMsg, err)
-					break
+					if strictExport {
+						logger.Fatal(errorMsg, err)
+					} else {
+						logger.Warning(errorMsg, err)
+						continue
+					}
 				}
 
 				transformedOffers = append(transformedOffers, offer)
@@ -278,8 +286,12 @@ func ReceiveChanges(accChannel, offChannel, trustChannel chan ChangeBatch, logge
 				if err != nil {
 					entry, _, _ := utils.ExtractEntryFromChange(change)
 					errorMsg := fmt.Sprintf("error transforming trustline entry last updated at: %d", entry.LastModifiedLedgerSeq)
-					logger.Error(errorMsg, err)
-					break
+					if strictExport {
+						logger.Fatal(errorMsg, err)
+					} else {
+						logger.Warning(errorMsg, err)
+						continue
+					}
 				}
 
 				transformedTrustlines = append(transformedTrustlines, trust)

--- a/internal/transform/ledger.go
+++ b/internal/transform/ledger.go
@@ -96,18 +96,20 @@ func extractCounts(lcm xdr.LedgerCloseMetaV0) (transactionCount int32, operation
 
 	txSetOperationCounter := int32(0)
 	for i := 0; i < txCount; i++ {
-		operationResults, ok := results[i].Result.OperationResults()
-		if !ok {
-			err = fmt.Errorf("Could not access operation results for result %d", i)
-			return
-		}
-
-		numberOfOps := int32(len(operationResults))
+		operations := transactions[i].Operations()
+		numberOfOps := int32(len(operations))
 		txSetOperationCounter += numberOfOps
 
+		// for successful transactions, the operation count is based on the operations results slice
 		if results[i].Result.Successful() {
+			operationResults, ok := results[i].Result.OperationResults()
+			if !ok {
+				err = fmt.Errorf("Could not access operation results for result %d", i)
+				return
+			}
+
 			successTxCount++
-			operationCount += numberOfOps
+			operationCount += int32(len(operationResults))
 		} else {
 			failedTxCount++
 		}

--- a/internal/transform/trade.go
+++ b/internal/transform/trade.go
@@ -28,6 +28,7 @@ func TransformTrade(operationIndex int32, operationID int64, transaction ingesti
 	if err != nil {
 		return []TradeOutput{}, err
 	}
+	
 	var outputCounterOfferID int64
 	if counterOffer != nil {
 		outputCounterOfferID = int64(counterOffer.OfferId)

--- a/internal/utils/main.go
+++ b/internal/utils/main.go
@@ -102,27 +102,27 @@ func CreateSampleResultMeta(successful bool, subOperationCount int) xdr.Transact
 	}
 }
 
-// AddBasicFlags adds the start-ledger, end-ledger, limit, output, and stdout flags to the provided flagset
-func AddBasicFlags(objectName string, flags *pflag.FlagSet) {
-	AddRangeFlags(flags)
-	AddOutputFlags(objectName, flags)
+// AddCommonFlags adds the flags common to all commands: end-ledger, stdout, and strict-export
+func AddCommonFlags(flags *pflag.FlagSet) {
+	flags.Uint32P("end-ledger", "e", 0, "The ledger sequence number for the end of the export range")
+	flags.Bool("stdout", false, "If set, the output will be printed to stdout instead of to a file")
+	flags.Bool("strict-export", false, "If set, transform errors will be reported as fatal errors instead of warnings.")
+}
+
+// AddArchiveFlags adds the history archive specific flags: start-ledger, output, and limit
+func AddArchiveFlags(objectName string, flags *pflag.FlagSet) {
+	flags.Uint32P("start-ledger", "s", 1, "The ledger sequence number for the beginning of the export period. Defaults to genesis ledger")
+	flags.StringP("output", "o", "exported_"+objectName+".txt", "Filename of the output file")
 	flags.Int64P("limit", "l", -1, "Maximum number of "+objectName+" to export. If the limit is set to a negative number, all the objects in the provided range are exported")
 
 }
 
-// AddRangeFlags adds the start-ledger and end-ledger flags
-func AddRangeFlags(flags *pflag.FlagSet) {
-	flags.Uint32P("start-ledger", "s", 1, "The ledger sequence number for the beginning of the export period. Defaults to genesis ledger")
-	flags.Uint32P("end-ledger", "e", 0, "The ledger sequence number for the end of the export range (required)")
-}
-
-// AddOutputFlags adds the output and stdout flags
-func AddOutputFlags(objectName string, flags *pflag.FlagSet) {
+// AddBucketFlags adds the bucket list specifc flags: output
+func AddBucketFlags(objectName string, flags *pflag.FlagSet) {
 	flags.StringP("output", "o", "exported_"+objectName+".txt", "Filename of the output file")
-	flags.Bool("stdout", false, "If set, the output will be printed to stdout instead of to a file")
 }
 
-// AddCoreFlags adds the core-executable, core-config, batch-size, and export{type} flags, which are needed for commands that use captive core
+// AddCoreFlags adds the captive core specifc flags: core-executable, core-config, batch-size, output, and the export-{type} flags
 func AddCoreFlags(flags *pflag.FlagSet) {
 	flags.StringP("core-executable", "x", "", "Filepath to the stellar-core executable")
 	flags.StringP("core-config", "c", "", "Filepath to the a config file for stellar-core")
@@ -132,47 +132,14 @@ func AddCoreFlags(flags *pflag.FlagSet) {
 	flags.BoolP("export-offers", "f", false, "set in order to export offer changes")
 
 	flags.Uint32P("batch-size", "b", 64, "number of ledgers to export changes from in each batches")
+	flags.StringP("output", "o", "changes_output/", "Folder that will contain the output files")
 }
 
-// AddBucketFlags adds the end-ledger, output, and stdout flags, which are needed for commands that use the bucket list
-func AddBucketFlags(objectName string, flags *pflag.FlagSet) {
-	flags.Uint32P("end-ledger", "e", 0, "The ledger sequence number for the end of the export range (required)")
-	flags.StringP("output", "o", "exported_"+objectName+".txt", "Filename of the output file")
-	flags.Bool("stdout", false, "If set, the output will be printed to stdout instead of to a file")
-}
-
-// MustBasicFlags gets the values of the start-ledger, end-ledger, limit, output, and stdout flags from the flag set. If any do not exist, it stops the program fatally using the logger
-func MustBasicFlags(flags *pflag.FlagSet, logger *log.Entry) (startNum, endNum uint32, limit int64, path string, useStdout bool) {
-	startNum, endNum = MustRangeFlags(flags, logger)
-	path, useStdout = MustOutputFlags(flags, logger)
-	limit, err := flags.GetInt64("limit")
-	if err != nil {
-		logger.Fatal("could not get limit: ", err)
-	}
-
-	return
-}
-
-// MustRangeFlags gets the values of the start-ledger and end-ledger flags
-func MustRangeFlags(flags *pflag.FlagSet, logger *log.Entry) (startNum, endNum uint32) {
-	startNum, err := flags.GetUint32("start-ledger")
-	if err != nil {
-		logger.Fatal("could not get start sequence number: ", err)
-	}
-
-	endNum, err = flags.GetUint32("end-ledger")
+// MustCommonFlags gets the values of the the flags common to all commands: end-ledger, stdout, and strict-export. If any do not exist, it stops the program fatally using the logger
+func MustCommonFlags(flags *pflag.FlagSet, logger *log.Entry) (endNum uint32, useStdout bool, strictExport bool) {
+	endNum, err := flags.GetUint32("end-ledger")
 	if err != nil {
 		logger.Fatal("could not get end sequence number: ", err)
-	}
-
-	return
-}
-
-// MustOutputFlags gets the values of the output and stdout flags
-func MustOutputFlags(flags *pflag.FlagSet, logger *log.Entry) (path string, useStdout bool) {
-	path, err := flags.GetString("output")
-	if err != nil {
-		logger.Fatal("could not get output filename: ", err)
 	}
 
 	useStdout, err = flags.GetBool("stdout")
@@ -180,11 +147,46 @@ func MustOutputFlags(flags *pflag.FlagSet, logger *log.Entry) (path string, useS
 		logger.Fatal("could not get stdout boolean: ", err)
 	}
 
+	strictExport, err = flags.GetBool("strict-export")
+	if err != nil {
+		logger.Fatal("could not get strict-export boolean: ", err)
+	}
+
 	return
 }
 
-// MustCoreFlags gets the values for the core-executable, core-config, batch-size, and export{type} flags. If any do not exist, it stops the program fatally using the logger
-func MustCoreFlags(flags *pflag.FlagSet, logger *log.Entry) (execPath, configPath string, exportAccounts, exportOffers, exportTrustlines bool, batchSize uint32) {
+// MustArchiveFlags gets the values of the the history archive specific flags: start-ledger, output, and limit
+func MustArchiveFlags(flags *pflag.FlagSet, logger *log.Entry) (startNum uint32, path string, limit int64) {
+	startNum, err := flags.GetUint32("start-ledger")
+	if err != nil {
+		logger.Fatal("could not get start sequence number: ", err)
+	}
+
+	path, err = flags.GetString("output")
+	if err != nil {
+		logger.Fatal("could not get output filename: ", err)
+	}
+
+	limit, err = flags.GetInt64("limit")
+	if err != nil {
+		logger.Fatal("could not get limit: ", err)
+	}
+
+	return
+}
+
+// MustBucketFlags gets the values of the bucket list specific flags: output
+func MustBucketFlags(flags *pflag.FlagSet, logger *log.Entry) (path string) {
+	path, err := flags.GetString("output")
+	if err != nil {
+		logger.Fatal("could not get output filename: ", err)
+	}
+
+	return
+}
+
+// MustCoreFlags gets the values for the core-executable, core-config, start ledger batch-size, output, and export{type} flags. If any do not exist, it stops the program fatally using the logger
+func MustCoreFlags(flags *pflag.FlagSet, logger *log.Entry) (execPath, configPath string, startNum, batchSize uint32, path string, exportAccounts, exportOffers, exportTrustlines bool) {
 	execPath, err := flags.GetString("core-executable")
 	if err != nil {
 		logger.Fatal("could not get path to stellar-core executable, which is mandatory when not starting at the genesis ledger (ledger 1): ", err)
@@ -193,6 +195,21 @@ func MustCoreFlags(flags *pflag.FlagSet, logger *log.Entry) (execPath, configPat
 	configPath, err = flags.GetString("core-config")
 	if err != nil {
 		logger.Fatal("could not get path to stellar-core config file, is mandatory when not starting at the genesis ledger (ledger 1): ", err)
+	}
+
+	path, err = flags.GetString("output")
+	if err != nil {
+		logger.Fatal("could not get output filename: ", err)
+	}
+
+	startNum, err = flags.GetUint32("start-ledger")
+	if err != nil {
+		logger.Fatal("could not get start sequence number: ", err)
+	}
+
+	batchSize, err = flags.GetUint32("batch-size")
+	if err != nil {
+		logger.Fatal("could not get batch size: ", err)
 	}
 
 	exportAccounts, err = flags.GetBool("export-accounts")
@@ -208,31 +225,6 @@ func MustCoreFlags(flags *pflag.FlagSet, logger *log.Entry) (execPath, configPat
 	exportTrustlines, err = flags.GetBool("export-trustlines")
 	if err != nil {
 		logger.Fatal("could not get export trustlines flag: ", err)
-	}
-
-	batchSize, err = flags.GetUint32("batch-size")
-	if err != nil {
-		logger.Fatal("could not get batch size: ", err)
-	}
-
-	return
-}
-
-// MustBucketFlags gets the values of the end-ledger, output, and stdout flags from the flag set. If any do not exist, it stops the program fatally using the logger
-func MustBucketFlags(flags *pflag.FlagSet, logger *log.Entry) (endNum uint32, path string, useStdout bool) {
-	endNum, err := flags.GetUint32("end-ledger")
-	if err != nil {
-		logger.Fatal("could not get end sequence number: ", err)
-	}
-
-	path, err = flags.GetString("output")
-	if err != nil {
-		logger.Fatal("could not get output filename: ", err)
-	}
-
-	useStdout, err = flags.GetBool("stdout")
-	if err != nil {
-		logger.Fatal("could not get stdout boolean: ", err)
 	}
 
 	return


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What
This PR reduces the default severity of transform failures to warnings. It also introduces a flag that will return transform failures to their old severity (fatal). Closes #104.

### Why
The old default behavior was very brittle. We would like a higher failure tolerance for the stellar-etl by default, with the option to treat errors more seriously with CLI flags
 
### Known limitations 