### PR TITLE
Add orderbook transform

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -437,6 +437,7 @@ github.com/stellar/go v0.0.0-20200831172902-bdde26347d0c h1:b63+ci6Av0CralnPZL0b
 github.com/stellar/go v0.0.0-20200914163951-8742d333c65d h1:wD8sI0cW0MzXwXVrWaqID/YrET3d0Ni7A2fBryER0Ig=
 github.com/stellar/go v0.0.0-20200917104244-8dc2a7354bf8 h1:hdrW8jhTrR6bagF4gzfItdiI/xeRv3FjptWco2Toz7I=
 github.com/stellar/go v0.0.0-20200918155524-d6803f9c1eb8 h1:tJGSSsR1zKxHOhHp2KHKQDy3GLmoczB133uR94ea744=
+github.com/stellar/go v0.0.0-20201027155406-0b17a675ec5a h1:GEhCKV2l3vusqVQCNrhszOK296D2Yvl4lagEN5b2yI8=
 github.com/stellar/go-xdr v0.0.0-20200331223602-71a1e6d555f2 h1:K9H+A+eWe8ZlnpNha+pXbEK+jtIluQp/2dKxkK8k7OE=
 github.com/stellar/go-xdr v0.0.0-20200331223602-71a1e6d555f2/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=

--- a/internal/transform/offer_normalized.go
+++ b/internal/transform/offer_normalized.go
@@ -1,0 +1,171 @@
+package transform
+
+import (
+	"fmt"
+	"hash/fnv"
+	"sort"
+	"strings"
+
+	ingestio "github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/stellar-etl/internal/utils"
+)
+
+// TransformOfferNormalized converts an offer into a normalized form, allowing it to be stored as part of the historical orderbook dataset
+func TransformOfferNormalized(ledgerChange ingestio.Change, ledgerSeq uint32) (NormalizedOfferOutput, error) {
+	normalized := NormalizedOfferOutput{}
+	transformed, err := TransformOffer(ledgerChange)
+	if err != nil {
+		return NormalizedOfferOutput{}, err
+	}
+
+	if transformed.Deleted {
+		return NormalizedOfferOutput{}, nil
+	}
+
+	err = modifyOfferAsset(ledgerChange, &transformed)
+	if err != nil {
+		return NormalizedOfferOutput{}, err
+	}
+
+	normalized.Market, err = extractDimMarket(transformed)
+	if err != nil {
+		return NormalizedOfferOutput{}, err
+	}
+
+	normalized.Account, err = extractDimAccount(transformed)
+	if err != nil {
+		return NormalizedOfferOutput{}, err
+	}
+
+	normalized.Offer, err = extractDimOffer(transformed, normalized.Market.ID, normalized.Account.ID)
+	if err != nil {
+		return NormalizedOfferOutput{}, err
+	}
+
+	normalized.Event = FactOfferEvent{
+		LedgerSeq:       ledgerSeq,
+		OfferInstanceID: normalized.Offer.DimOfferID,
+	}
+
+	return normalized, nil
+}
+
+// modifyOfferAsset changes the buying and selling asset of a transformed offer from the asset hash to a string of the format code:issuer
+func modifyOfferAsset(ledgerChange ingestio.Change, transformed *OfferOutput) error {
+	ledgerEntry, _, err := utils.ExtractEntryFromChange(ledgerChange)
+	if err != nil {
+		return err
+	}
+
+	offerEntry, offerFound := ledgerEntry.Data.GetOffer()
+	if !offerFound {
+		return fmt.Errorf("Could not extract offer data from ledger entry; actual type is %s", ledgerEntry.Data.Type)
+	}
+
+	var sellType, sellCode, sellIssuer string
+	err = offerEntry.Selling.Extract(&sellType, &sellCode, &sellIssuer)
+	if err != nil {
+		return err
+	}
+
+	var outputSellingAsset string
+	if sellType != "native" {
+		outputSellingAsset = fmt.Sprintf("%s:%s", sellCode, sellIssuer)
+	} else {
+		// native assets have an empty issuer
+		outputSellingAsset = "native:"
+	}
+
+	var buyType, buyCode, buyIssuer string
+	err = offerEntry.Buying.Extract(&buyType, &buyCode, &buyIssuer)
+	if err != nil {
+		return err
+	}
+
+	var outputBuyingAsset string
+	if buyType != "native" {
+		outputBuyingAsset = fmt.Sprintf("%s:%s", buyCode, buyIssuer)
+	} else {
+		outputBuyingAsset = "native:"
+	}
+
+	transformed.BuyingAsset = outputBuyingAsset
+	transformed.SellingAsset = outputSellingAsset
+	return nil
+}
+
+// extractDimMarket gets the DimMarket struct that corresponds to the provided offer
+func extractDimMarket(offer OfferOutput) (DimMarket, error) {
+	assets := []string{offer.BuyingAsset, offer.SellingAsset}
+	// sort in order to ensure markets have consistent base/counter pairs
+	// markets are stored as selling/buying == base/counter
+	sort.Strings(assets)
+
+	fnvHasher := fnv.New64a()
+	if _, err := fnvHasher.Write([]byte(strings.Join(assets, "/"))); err != nil {
+		return DimMarket{}, err
+	}
+
+	hash := fnvHasher.Sum64()
+
+	sellSplit := strings.Split(assets[0], ":")
+	buySplit := strings.Split(assets[1], ":")
+
+	baseCode, baseIssuer := sellSplit[0], sellSplit[1]
+	counterCode, counterIssuer := buySplit[0], buySplit[1]
+
+	return DimMarket{
+		ID:            hash,
+		BaseCode:      baseCode,
+		BaseIssuer:    baseIssuer,
+		CounterCode:   counterCode,
+		CounterIssuer: counterIssuer,
+	}, nil
+}
+
+// extractDimOffer extracts the DimOffer struct from the provided offer
+func extractDimOffer(offer OfferOutput, marketID, makerID uint64) (DimOffer, error) {
+	importantFields := fmt.Sprintf("%d/%d/%f", offer.OfferID, offer.Amount, offer.Price)
+
+	fnvHasher := fnv.New64a()
+	if _, err := fnvHasher.Write([]byte(importantFields)); err != nil {
+		return DimOffer{}, err
+	}
+
+	offerHash := fnvHasher.Sum64()
+
+	assets := []string{offer.BuyingAsset, offer.SellingAsset}
+	sort.Strings(assets)
+
+	var action string
+	if offer.SellingAsset == assets[0] {
+		action = "s"
+	} else {
+		action = "b"
+	}
+
+	return DimOffer{
+		HorizonID:     offer.OfferID,
+		DimOfferID:    offerHash,
+		MarketID:      marketID,
+		MakerID:       makerID,
+		Action:        action,
+		BaseAmount:    offer.Amount,
+		CounterAmount: float64(offer.Amount) * offer.Price,
+		Price:         offer.Price,
+	}, nil
+}
+
+// extractDimAccount gets the DimAccount struct that corresponds to the provided offer
+func extractDimAccount(offer OfferOutput) (DimAccount, error) {
+	var fnvHasher = fnv.New64a()
+	if _, err := fnvHasher.Write([]byte(offer.SellerID)); err != nil {
+		return DimAccount{}, err
+	}
+
+	accountID := fnvHasher.Sum64()
+	return DimAccount{
+		Address: offer.SellerID,
+		ID:      accountID,
+	}, nil
+}

--- a/internal/transform/offer_normalized_test.go
+++ b/internal/transform/offer_normalized_test.go
@@ -1,0 +1,120 @@
+package transform
+
+import (
+	"testing"
+
+	ingestio "github.com/stellar/go/exp/ingest/io"
+	"github.com/stellar/go/xdr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransformOfferNormalized(t *testing.T) {
+	type testInput struct {
+		change ingestio.Change
+		ledger uint32
+	}
+	type transformTest struct {
+		input      testInput
+		wantOutput NormalizedOfferOutput
+		wantErr    error
+	}
+
+	hardCodedInput, err := makeOfferNormalizedTestInput()
+	assert.NoError(t, err)
+	hardCodedOutput := makeOfferNormalizedTestOutput()
+
+	tests := []transformTest{
+		{
+			input: testInput{ingestio.Change{
+				Type: xdr.LedgerEntryTypeOffer,
+				Pre: &xdr.LedgerEntry{
+					LastModifiedLedgerSeq: xdr.Uint32(100),
+					Data: xdr.LedgerEntryData{
+						Type: xdr.LedgerEntryTypeOffer,
+						Offer: &xdr.OfferEntry{
+							SellerId: genericAccountID,
+							Price: xdr.Price{
+								N: 5,
+								D: 34,
+							},
+						},
+					},
+				},
+				Post: nil,
+			}, 100},
+			wantOutput: NormalizedOfferOutput{},
+			wantErr:    nil,
+		},
+		{
+			input:      testInput{hardCodedInput, 100},
+			wantOutput: hardCodedOutput,
+			wantErr:    nil,
+		},
+	}
+
+	for _, test := range tests {
+		actualOutput, actualError := TransformOfferNormalized(test.input.change, test.input.ledger)
+		assert.Equal(t, test.wantErr, actualError)
+		assert.Equal(t, test.wantOutput, actualOutput)
+	}
+}
+
+func makeOfferNormalizedTestInput() (ledgerChange ingestio.Change, err error) {
+	ledgerChange = ingestio.Change{
+		Type: xdr.LedgerEntryTypeOffer,
+		Pre:  nil,
+		Post: &xdr.LedgerEntry{
+			LastModifiedLedgerSeq: xdr.Uint32(30715263),
+			Data: xdr.LedgerEntryData{
+				Type: xdr.LedgerEntryTypeOffer,
+				Offer: &xdr.OfferEntry{
+					SellerId: testAccount1ID,
+					OfferId:  260678439,
+					Selling:  nativeAsset,
+					Buying:   ethAsset,
+					Amount:   2628450327,
+					Price: xdr.Price{
+						N: 920936891,
+						D: 1790879058,
+					},
+					Flags: 2,
+				},
+			},
+		},
+	}
+	return
+}
+
+func makeOfferNormalizedTestOutput() NormalizedOfferOutput {
+	var dimOfferID, marketID, accountID uint64
+	dimOfferID = 2427794722528467255
+	marketID = 10357275879248593505
+	accountID = 4268167189990212240
+	return NormalizedOfferOutput{
+		Market: DimMarket{
+			ID:            marketID,
+			BaseCode:      "ETH",
+			BaseIssuer:    testAccount3Address,
+			CounterCode:   "native",
+			CounterIssuer: "",
+		},
+		Offer: DimOffer{
+			HorizonID:     260678439,
+			DimOfferID:    dimOfferID,
+			MarketID:      marketID,
+			MakerID:       accountID,
+			Action:        "b",
+			BaseAmount:    2628450327,
+			CounterAmount: 1351647316.1502085,
+			Price:         0.5142373444404865,
+		},
+		Account: DimAccount{
+			Address: testAccount1Address,
+			ID:      accountID,
+		},
+		Event: FactOfferEvent{
+			LedgerSeq:       100,
+			OfferInstanceID: dimOfferID,
+		},
+	}
+}

--- a/internal/transform/offer_normalized_test.go
+++ b/internal/transform/offer_normalized_test.go
@@ -1,6 +1,7 @@
 package transform
 
 import (
+	"fmt"
 	"testing"
 
 	ingestio "github.com/stellar/go/exp/ingest/io"
@@ -43,7 +44,7 @@ func TestTransformOfferNormalized(t *testing.T) {
 				Post: nil,
 			}, 100},
 			wantOutput: NormalizedOfferOutput{},
-			wantErr:    nil,
+			wantErr:    fmt.Errorf("offer 0 is deleted"),
 		},
 		{
 			input:      testInput{hardCodedInput, 100},

--- a/internal/transform/schema.go
+++ b/internal/transform/schema.go
@@ -197,3 +197,44 @@ type TradeOutput struct {
 	CounterOfferID        int64     `json:"counter_offer_id"`
 	HistoryOperationID    int64     `json:"history_operation_id"`
 }
+
+//DimAccount is a representation of an account that aligns with the BigQuery table dim_accounts
+type DimAccount struct {
+	ID      uint64 `json:"account_id"`
+	Address string `json:"address"`
+}
+
+//DimOffer is a representation of an account that aligns with the BigQuery table dim_offers
+type DimOffer struct {
+	HorizonID     int64   `json:"horizon_offer_id"`
+	DimOfferID    uint64  `json:"dim_offer_id"`
+	MarketID      uint64  `json:"market_id"`
+	MakerID       uint64  `json:"maker_id"`
+	Action        string  `json:"action"`
+	BaseAmount    int64   `json:"base_amount"`
+	CounterAmount float64 `json:"counter_amount"`
+	Price         float64 `json:"price"`
+}
+
+// FactOfferEvent is a representation of an offer event that aligns with the BigQuery table fact_offer_events
+type FactOfferEvent struct {
+	LedgerSeq       uint32 `json:"ledger_id"`
+	OfferInstanceID uint64 `json:"offer_instance_id"`
+}
+
+// DimMarket is a representation of an account that aligns with the BigQuery table dim_markets
+type DimMarket struct {
+	ID            uint64 `json:"market_id"`
+	BaseCode      string `json:"base_code"`
+	BaseIssuer    string `json:"base_issuer"`
+	CounterCode   string `json:"counter_code"`
+	CounterIssuer string `json:"counter_issuer"`
+}
+
+// NormalizedOfferOutput ties together the information for dim_markets, dim_offers, dim_accounts, and fact_offer-events
+type NormalizedOfferOutput struct {
+	Market  DimMarket
+	Offer   DimOffer
+	Account DimAccount
+	Event   FactOfferEvent
+}

--- a/internal/transform/schema.go
+++ b/internal/transform/schema.go
@@ -204,7 +204,7 @@ type DimAccount struct {
 	Address string `json:"address"`
 }
 
-//DimOffer is a representation of an account that aligns with the BigQuery table dim_offers
+// DimOffer is a representation of an account that aligns with the BigQuery table dim_offers
 type DimOffer struct {
 	HorizonID     int64   `json:"horizon_offer_id"`
 	DimOfferID    uint64  `json:"dim_offer_id"`

--- a/internal/utils/main.go
+++ b/internal/utils/main.go
@@ -269,7 +269,7 @@ func ExtractLedgerCloseTime(ledger xdr.LedgerCloseMeta) (time.Time, error) {
 	return TimePointToUTCTimeStamp(close)
 }
 
-// ExtractEntryFromChange gets the close time of the provided ledger
+// ExtractEntryFromChange gets the most recent state of an entry from an ingestio change, as well as if the entry was deleted
 func ExtractEntryFromChange(change ingestio.Change) (xdr.LedgerEntry, bool, error) {
 	switch changeType := change.LedgerEntryChangeType(); changeType {
 	case xdr.LedgerEntryChangeTypeLedgerEntryCreated, xdr.LedgerEntryChangeTypeLedgerEntryUpdated:


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What
This PR adds the transform normalized offers. It transforms offers and separates data in a manner that is consistent with the planned schemas for storing historical orderbooks. First part of #108.

### Why
We want to store historical orderbooks to support the queries on historical liquidity in markets. The current offer transform is good for storing point in time data, but this transform reduces the final storage usage of the tables.
 
### Known limitations 
The full command has not yet been implemented.