### PR TITLE
stellar-etl: fix unbounded orderbooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /local-archive
 /.vscode/*.sql
 /.vscode/settings.json
+/.vscode/launch.json
 .idea
 debug
 .bundle

--- a/cmd/export_ledgers_test.go
+++ b/cmd/export_ledgers_test.go
@@ -103,7 +103,6 @@ func TestExportLedger(t *testing.T) {
 	}
 }
 
-// TODO: add a testing flag that outputs to stdout and read from there instead of reading back from a test file
 func runCLITest(t *testing.T, test cliTest, goldenFolder string) {
 	t.Run(test.name, func(t *testing.T) {
 		dir, err := os.Getwd()

--- a/cmd/export_orderbooks.go
+++ b/cmd/export_orderbooks.go
@@ -62,8 +62,7 @@ var exportOrderbooksCmd = &cobra.Command{
 		if err != nil {
 			cmdLogger.Fatal("could not read initial orderbook: ", err)
 		}
-
-		input.UpdateOrderbook(checkpointSeq, startNum, orderbook, core, cmdLogger)
+		
 		orderbookChannel := make(chan input.OrderbookBatch)
 
 		go input.StreamOrderbooks(core, startNum, endNum, batchSize, orderbookChannel, orderbook, cmdLogger)

--- a/go.sum
+++ b/go.sum
@@ -437,6 +437,7 @@ github.com/stellar/go v0.0.0-20201028171940-a89275a19a1c h1:NivjyjiviPxddGzm/qOu
 github.com/stellar/go v0.0.0-20201028171940-a89275a19a1c/go.mod h1:detHj8OVJH7sNNGahphTD9kMofOxMKAURZuRq9mHwGM=
 github.com/stellar/go v0.0.0-20201029160206-0b0146ae1cdc h1:Btn5EK0E456rfHMP8OSk9+qIJpJODEvSs3umYmHufgw=
 github.com/stellar/go v0.0.0-20201029210512-8b3ca5968c1e h1:Ty3PNg66YmtuFKiyniXj7oqcBVD4A+ceoF9LA7ewrgU=
+github.com/stellar/go v0.0.0-20201030153712-c0a8ad31f460 h1:JOZ0HDkUSiGA9uiKwTrKYadoIdDtQfYjMwc+64OYk30=
 github.com/stellar/go-xdr v0.0.0-20200331223602-71a1e6d555f2 h1:K9H+A+eWe8ZlnpNha+pXbEK+jtIluQp/2dKxkK8k7OE=
 github.com/stellar/go-xdr v0.0.0-20200331223602-71a1e6d555f2/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).
</details>

### What
This PR fixes a problem in the code where the orderbook for future ledgers was being created before the ledgers themselves were available. 

### Why
The command wasn't working correctly for unbounded ranges. We needed to fix that for the Airflow integration.

### Known limitations 
N/A