### PR TITLE
Add Fee Bumps, Muxed Accounts to Transactions

### DIFF
--- a/internal/transform/schema.go
+++ b/internal/transform/schema.go
@@ -33,6 +33,7 @@ type TransactionOutput struct {
 	LedgerSequence       uint32    `json:"ledger_sequence"`
 	ApplicationOrder     uint32    `json:"application_order"`
 	Account              string    `json:"account"`
+	AccountMuxed         string    `json:"account_muxed,omitempty"`
 	AccountSequence      int64     `json:"account_sequence"`
 	MaxFee               uint32    `json:"max_fee"`
 	FeeCharged           int64     `json:"fee_charged"`

--- a/internal/transform/schema.go
+++ b/internal/transform/schema.go
@@ -29,20 +29,24 @@ type LedgerOutput struct {
 
 // TransactionOutput is a representation of a transaction that aligns with the BigQuery table history_transactions
 type TransactionOutput struct {
-	TransactionHash  string    `json:"transaction_hash"`
-	LedgerSequence   uint32    `json:"ledger_sequence"`
-	ApplicationOrder uint32    `json:"application_order"`
-	Account          string    `json:"account"`
-	AccountSequence  int64     `json:"account_sequence"`
-	MaxFee           uint32    `json:"max_fee"`
-	FeeCharged       int64     `json:"fee_charged"`
-	OperationCount   int32     `json:"operation_count"`
-	CreatedAt        time.Time `json:"created_at"`
-	MemoType         string    `json:"memo_type"`
-	Memo             string    `json:"memo"`
-	TimeBounds       string    `json:"time_bounds"`
-	Successful       bool      `json:"successful"`
-	TransactionID    int64     `json:"id"`
+	TransactionHash      string    `json:"transaction_hash"`
+	LedgerSequence       uint32    `json:"ledger_sequence"`
+	ApplicationOrder     uint32    `json:"application_order"`
+	Account              string    `json:"account"`
+	AccountSequence      int64     `json:"account_sequence"`
+	MaxFee               uint32    `json:"max_fee"`
+	FeeCharged           int64     `json:"fee_charged"`
+	OperationCount       int32     `json:"operation_count"`
+	CreatedAt            time.Time `json:"created_at"`
+	MemoType             string    `json:"memo_type"`
+	Memo                 string    `json:"memo"`
+	TimeBounds           string    `json:"time_bounds"`
+	Successful           bool      `json:"successful"`
+	TransactionID        int64     `json:"id"`
+	FeeAccount           string    `json:"fee_account,omitempty"`
+	FeeAccountMuxed      string    `json:"fee_account_muxed,omitempty"`
+	InnerTransactionHash string    `json:"inner_transaction_hash,omitempty"`
+	NewMaxFee            uint32    `json:"new_max_fee,omitempty"`
 }
 
 // AccountOutput is a representation of an account that aligns with the BigQuery table accounts

--- a/internal/transform/transaction.go
+++ b/internal/transform/transaction.go
@@ -2,6 +2,7 @@ package transform
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 
@@ -22,6 +23,7 @@ func TransformTransaction(transaction ingest.LedgerTransaction, lhe xdr.LedgerHe
 
 	outputTransactionID := toid.New(int32(outputLedgerSequence), int32(outputApplicationOrder), 0).ToInt64()
 
+	sourceAccount := transaction.Envelope.SourceAccount()
 	outputAccount, err := utils.GetAccountAddressFromMuxedAccount(transaction.Envelope.SourceAccount())
 	if err != nil {
 		return TransactionOutput{}, fmt.Errorf("for ledger %d; transaction %d (transaction id=%d): %v", outputLedgerSequence, outputApplicationOrder, outputTransactionID, err)
@@ -92,5 +94,19 @@ func TransformTransaction(transaction ingest.LedgerTransaction, lhe xdr.LedgerHe
 		TimeBounds:       outputTimeBounds,
 		Successful:       outputSuccessful,
 	}
+
+	if transaction.Envelope.IsFeeBump() {
+		feeBumpAccount := transaction.Envelope.FeeBumpAccount()
+		feeAccount := feeBumpAccount.ToAccountId()
+		if sourceAccount.Type == xdr.CryptoKeyTypeKeyTypeMuxedEd25519 {
+			feeAccountMuxed := feeAccount.Address()
+			transformedTransaction.FeeAccountMuxed = feeAccountMuxed
+		}
+		transformedTransaction.FeeAccount = feeAccount.Address()
+		innerHash := transaction.Result.InnerHash()
+		transformedTransaction.InnerTransactionHash = hex.EncodeToString(innerHash[:])
+		transformedTransaction.NewMaxFee = uint32(transaction.Envelope.FeeBumpFee())
+	}
+
 	return transformedTransaction, nil
 }

--- a/internal/transform/transaction.go
+++ b/internal/transform/transaction.go
@@ -95,6 +95,17 @@ func TransformTransaction(transaction ingest.LedgerTransaction, lhe xdr.LedgerHe
 		Successful:       outputSuccessful,
 	}
 
+	// Add Muxed Account Details, if exists
+	if sourceAccount.Type == xdr.CryptoKeyTypeKeyTypeMuxedEd25519 {
+		muxedAddress, err := sourceAccount.GetAddress()
+		if err != nil {
+			return TransactionOutput{}, err
+		}
+		transformedTransaction.AccountMuxed = muxedAddress
+
+	}
+
+	// Add Fee Bump Details, if exists
 	if transaction.Envelope.IsFeeBump() {
 		feeBumpAccount := transaction.Envelope.FeeBumpAccount()
 		feeAccount := feeBumpAccount.ToAccountId()

--- a/internal/transform/transaction_test.go
+++ b/internal/transform/transaction_test.go
@@ -40,7 +40,6 @@ func TestTransformTransaction(t *testing.T) {
 
 	hardCodedTransaction, hardCodedLedgerHeader, err := makeTransactionTestInput()
 	assert.NoError(t, err)
-	hardCodedInput := inputStruct{hardCodedTransaction, hardCodedLedgerHeader}
 	hardCodedOutput, err := makeTransactionTestOutput()
 	assert.NoError(t, err)
 
@@ -60,11 +59,14 @@ func TestTransformTransaction(t *testing.T) {
 			TransactionOutput{},
 			fmt.Errorf("The max time is earlier than the min time (100 < 1594586912) for ledger 0; transaction 1 (transaction id=4096)"),
 		},
-		{
-			hardCodedInput,
-			hardCodedOutput,
-			nil,
-		},
+	}
+
+	for i := range hardCodedTransaction {
+		tests = append(tests, transformTest{
+			input:      inputStruct{hardCodedTransaction[i], hardCodedLedgerHeader[i]},
+			wantOutput: hardCodedOutput[i],
+			wantErr:    nil,
+		})
 	}
 
 	for _, test := range tests {
@@ -74,75 +76,168 @@ func TestTransformTransaction(t *testing.T) {
 	}
 }
 
-func makeTransactionTestOutput() (output TransactionOutput, err error) {
+func makeTransactionTestOutput() (output []TransactionOutput, err error) {
 	correctTime, err := time.Parse("2006-1-2 15:04:05 MST", "2020-07-09 05:28:42 UTC")
-	output = TransactionOutput{
-		TransactionHash:  "a87fef5eeb260269c380f2de456aad72b59bb315aaac777860456e09dac0bafb",
-		LedgerSequence:   30521816,
-		ApplicationOrder: 1,
-		TransactionID:    131090201534533632,
-		Account:          testAccount1Address,
-		AccountSequence:  112351890582290871,
-		MaxFee:           90000,
-		FeeCharged:       300,
-		OperationCount:   1,
-		CreatedAt:        correctTime,
-		MemoType:         "MemoTypeMemoText",
-		Memo:             "HL5aCgozQHIW7sSc5XdcfmR",
-		TimeBounds:       "[0, 1594272628)",
-		Successful:       false,
+	output = []TransactionOutput{
+		TransactionOutput{
+			TransactionHash:  "a87fef5eeb260269c380f2de456aad72b59bb315aaac777860456e09dac0bafb",
+			LedgerSequence:   30521816,
+			ApplicationOrder: 1,
+			TransactionID:    131090201534533632,
+			Account:          testAccount1Address,
+			AccountSequence:  112351890582290871,
+			MaxFee:           90000,
+			FeeCharged:       300,
+			OperationCount:   1,
+			CreatedAt:        correctTime,
+			MemoType:         "MemoTypeMemoText",
+			Memo:             "HL5aCgozQHIW7sSc5XdcfmR",
+			TimeBounds:       "[0, 1594272628)",
+			Successful:       false,
+		},
+		TransactionOutput{
+			TransactionHash:      "a87fef5eeb260269c380f2de456aad72b59bb315aaac777860456e09dac0bafb",
+			LedgerSequence:       30521817,
+			ApplicationOrder:     1,
+			TransactionID:        131090205829500928,
+			Account:              testAccount1Address,
+			AccountSequence:      150015399398735997,
+			MaxFee:               0,
+			FeeCharged:           300,
+			OperationCount:       1,
+			CreatedAt:            correctTime,
+			MemoType:             "MemoTypeMemoText",
+			Memo:                 "HL5aCgozQHIW7sSc5XdcfmR",
+			TimeBounds:           "[0, 1594272628)",
+			Successful:           true,
+			InnerTransactionHash: "a87fef5eeb260269c380f2de456aad72b59bb315aaac777860456e09dac0bafb",
+			FeeAccount:           testAccount3Address,
+			NewMaxFee:            7200,
+		},
 	}
 	return
 }
-func makeTransactionTestInput() (transaction ingest.LedgerTransaction, historyHeader xdr.LedgerHeaderHistoryEntry, err error) {
+func makeTransactionTestInput() (transaction []ingest.LedgerTransaction, historyHeader []xdr.LedgerHeaderHistoryEntry, err error) {
 	hardCodedMemoText := "HL5aCgozQHIW7sSc5XdcfmR"
 	hardCodedTransactionHash := xdr.Hash([32]byte{0xa8, 0x7f, 0xef, 0x5e, 0xeb, 0x26, 0x2, 0x69, 0xc3, 0x80, 0xf2, 0xde, 0x45, 0x6a, 0xad, 0x72, 0xb5, 0x9b, 0xb3, 0x15, 0xaa, 0xac, 0x77, 0x78, 0x60, 0x45, 0x6e, 0x9, 0xda, 0xc0, 0xba, 0xfb})
-	transaction = ingest.LedgerTransaction{
-		Index: 1,
-		Envelope: xdr.TransactionEnvelope{
-			Type: xdr.EnvelopeTypeEnvelopeTypeTx,
-			V1: &xdr.TransactionV1Envelope{
-				Tx: xdr.Transaction{
-					SourceAccount: testAccount1,
-					SeqNum:        112351890582290871,
-					Memo: xdr.Memo{
-						Type: xdr.MemoTypeMemoText,
-						Text: &hardCodedMemoText,
-					},
-					Fee: 90000,
-					TimeBounds: &xdr.TimeBounds{
-						MinTime: 0,
-						MaxTime: 1594272628,
-					},
-					Operations: []xdr.Operation{
-						xdr.Operation{
-							SourceAccount: &testAccount2,
-							Body: xdr.OperationBody{
-								Type:                       xdr.OperationTypePathPaymentStrictReceive,
-								PathPaymentStrictReceiveOp: &xdr.PathPaymentStrictReceiveOp{},
+	transaction = []ingest.LedgerTransaction{
+		ingest.LedgerTransaction{
+			Index: 1,
+			Envelope: xdr.TransactionEnvelope{
+				Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+				V1: &xdr.TransactionV1Envelope{
+					Tx: xdr.Transaction{
+						SourceAccount: testAccount1,
+						SeqNum:        112351890582290871,
+						Memo: xdr.Memo{
+							Type: xdr.MemoTypeMemoText,
+							Text: &hardCodedMemoText,
+						},
+						Fee: 90000,
+						TimeBounds: &xdr.TimeBounds{
+							MinTime: 0,
+							MaxTime: 1594272628,
+						},
+						Operations: []xdr.Operation{
+							xdr.Operation{
+								SourceAccount: &testAccount2,
+								Body: xdr.OperationBody{
+									Type:                       xdr.OperationTypePathPaymentStrictReceive,
+									PathPaymentStrictReceiveOp: &xdr.PathPaymentStrictReceiveOp{},
+								},
 							},
 						},
 					},
 				},
 			},
+			Result: xdr.TransactionResultPair{
+				TransactionHash: hardCodedTransactionHash,
+				Result: xdr.TransactionResult{
+					FeeCharged: 300,
+					Result: xdr.TransactionResultResult{
+						Code: xdr.TransactionResultCodeTxFailed,
+						Results: &[]xdr.OperationResult{
+							xdr.OperationResult{},
+						},
+					},
+				},
+			},
 		},
-		Result: xdr.TransactionResultPair{
-			TransactionHash: hardCodedTransactionHash,
-			Result: xdr.TransactionResult{
-				FeeCharged: 300,
-				Result: xdr.TransactionResultResult{
-					Code: xdr.TransactionResultCodeTxFailed,
-					Results: &[]xdr.OperationResult{
-						xdr.OperationResult{},
+		ingest.LedgerTransaction{
+			Index: 1,
+			Envelope: xdr.TransactionEnvelope{
+				Type: xdr.EnvelopeTypeEnvelopeTypeTxFeeBump,
+				FeeBump: &xdr.FeeBumpTransactionEnvelope{
+					Tx: xdr.FeeBumpTransaction{
+						FeeSource: testAccount3,
+						Fee:       7200,
+						InnerTx: xdr.FeeBumpTransactionInnerTx{
+							Type: xdr.EnvelopeTypeEnvelopeTypeTx,
+							V1: &xdr.TransactionV1Envelope{
+								Tx: xdr.Transaction{
+									SourceAccount: testAccount1,
+									SeqNum:        150015399398735997,
+									Memo: xdr.Memo{
+										Type: xdr.MemoTypeMemoText,
+										Text: &hardCodedMemoText,
+									},
+									TimeBounds: &xdr.TimeBounds{
+										MinTime: 0,
+										MaxTime: 1594272628,
+									},
+									Operations: []xdr.Operation{
+										xdr.Operation{
+											SourceAccount: &testAccount2,
+											Body: xdr.OperationBody{
+												Type:                       xdr.OperationTypePathPaymentStrictReceive,
+												PathPaymentStrictReceiveOp: &xdr.PathPaymentStrictReceiveOp{},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Result: xdr.TransactionResultPair{
+				TransactionHash: hardCodedTransactionHash,
+				Result: xdr.TransactionResult{
+					FeeCharged: 300,
+					Result: xdr.TransactionResultResult{
+						Code: xdr.TransactionResultCodeTxFeeBumpInnerSuccess,
+						InnerResultPair: &xdr.InnerTransactionResultPair{
+							TransactionHash: hardCodedTransactionHash,
+							Result: xdr.InnerTransactionResult{
+								FeeCharged: 100,
+								Result: xdr.InnerTransactionResultResult{
+									Code: xdr.TransactionResultCodeTxFeeBumpInnerSuccess,
+									Results: &[]xdr.OperationResult{
+										xdr.OperationResult{},
+									},
+								},
+							},
+						},
+						Results: &[]xdr.OperationResult{
+							xdr.OperationResult{},
+						},
 					},
 				},
 			},
 		},
 	}
-	historyHeader = xdr.LedgerHeaderHistoryEntry{
-		Header: xdr.LedgerHeader{
-			LedgerSeq: 30521816,
-			ScpValue:  xdr.StellarValue{CloseTime: 1594272522},
+	historyHeader = []xdr.LedgerHeaderHistoryEntry{
+		xdr.LedgerHeaderHistoryEntry{
+			Header: xdr.LedgerHeader{
+				LedgerSeq: 30521816,
+				ScpValue:  xdr.StellarValue{CloseTime: 1594272522},
+			},
+		},
+		xdr.LedgerHeaderHistoryEntry{
+			Header: xdr.LedgerHeader{
+				LedgerSeq: 30521817,
+				ScpValue:  xdr.StellarValue{CloseTime: 1594272522},
+			},
 		},
 	}
 	return


### PR DESCRIPTION
Two important concepts were left off the `transform/transactions.go` file that need to be introduced to Hubble 2.0: 
1. Fee Bumps
2. Muxed Accounts

This PR introduces both to Hubble 2.0. Changes were minor, focusing primarily on

#### Schema Changes
The following fields were added to the `TransactionOutput` struct:

* `AccountMuxed`
* `FeeAccount`
* `FeeAccountMuxed`
* `InnerTransactionHash`
* `NewMaxFee`


#### New Code
* Code to parse InnerTransactionResult when there is a `FeeBump` included in the transaction
* Code to parse `MuxedAccounts` if the crypto signature matches

#### Unit Tests
An additional unit test was written for `transform/transactions.go`, which tests a successful Fee Bumped transaction. In order to add a unit test, the `makeTransactionTestInput` and `makeTransactionTestOutput` functions were refactored. In prior versions, both could only support structs. The type was updated to be an _array_ of structs for ease of multiple tests during test execution.