### PR TITLE
Update TrustLines to include Liquidity Pools

### DIFF
--- a/internal/transform/schema.go
+++ b/internal/transform/schema.go
@@ -3,6 +3,7 @@ package transform
 import (
 	"time"
 
+	"github.com/guregu/null"
 	"github.com/stellar/go/xdr"
 )
 
@@ -121,18 +122,20 @@ type AssetOutput struct {
 
 // TrustlineOutput is a representation of a trustline that aligns with the BigQuery table trust_lines
 type TrustlineOutput struct {
-	LedgerKey          string `json:"ledger_key"`
-	AccountID          string `json:"account_id"`
-	AssetCode          string `json:"asset_code"`
-	AssetIssuer        string `json:"asset_issuer"`
-	AssetType          int32  `json:"asset_type"`
-	Balance            int64  `json:"balance"`
-	TrustlineLimit     int64  `json:"trust_line_limit"`
-	BuyingLiabilities  int64  `json:"buying_liabilities"`
-	SellingLiabilities int64  `json:"selling_liabilities"`
-	Flags              uint32 `json:"flags"`
-	LastModifiedLedger uint32 `json:"last_modified_ledger"`
-	Deleted            bool   `json:"deleted"`
+	LedgerKey          string      `json:"ledger_key"`
+	AccountID          string      `json:"account_id"`
+	AssetCode          string      `json:"asset_code"`
+	AssetIssuer        string      `json:"asset_issuer"`
+	AssetType          int32       `json:"asset_type"`
+	Balance            int64       `json:"balance"`
+	TrustlineLimit     int64       `json:"trust_line_limit"`
+	LiquidityPoolID    string      `json:"liquidity_pool_id"`
+	BuyingLiabilities  int64       `json:"buying_liabilities"`
+	SellingLiabilities int64       `json:"selling_liabilities"`
+	Flags              uint32      `json:"flags"`
+	LastModifiedLedger uint32      `json:"last_modified_ledger"`
+	Sponsor            null.String `json:"sponsor"`
+	Deleted            bool        `json:"deleted"`
 }
 
 // OfferOutput is a representation of an offer that aligns with the BigQuery table offers

--- a/internal/transform/test_variables_test.go
+++ b/internal/transform/test_variables_test.go
@@ -215,6 +215,11 @@ var ethAssetPath = Path{
 	AssetIssuer: testAccount1Address,
 }
 
+var liquidityPoolAsset = xdr.TrustLineAsset{
+	Type:            xdr.AssetTypeAssetTypePoolShare,
+	LiquidityPoolId: &xdr.PoolId{1, 3, 4, 5, 7, 9},
+}
+
 var nativeAsset = xdr.MustNewNativeAsset()
 var nativeAssetPath = Path{
 	AssetType: "native",

--- a/internal/transform/trustline.go
+++ b/internal/transform/trustline.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"github.com/guregu/null"
 	"github.com/pkg/errors"
 
 	"github.com/stellar/stellar-etl/internal/utils"
@@ -29,63 +30,39 @@ func TransformTrustline(ledgerChange ingest.Change) (TrustlineOutput, error) {
 		return TrustlineOutput{}, err
 	}
 
-	var assetType, outputAssetCode, outputAssetIssuer string
+	var assetType, outputAssetCode, outputAssetIssuer, poolID string
 
 	asset := trustEntry.Asset
-	err = asset.Extract(&assetType, &outputAssetCode, &outputAssetIssuer)
-	if err != nil {
-		return TrustlineOutput{}, errors.Wrap(err, fmt.Sprintf("could not parse asset for trustline with account %s", outputAccountID))
-	}
 
 	outputLedgerKey, err := trustLineEntryToLedgerKeyString(trustEntry)
 	if err != nil {
 		return TrustlineOutput{}, errors.Wrap(err, fmt.Sprintf("could not create ledger key string for trustline with account %s and asset %s", outputAccountID, asset.ToAsset().StringCanonical()))
 	}
 
-	outputAssetType := int32(asset.Type)
-
-	outputBalance := int64(trustEntry.Balance)
-	if outputBalance < 0 {
-		return TrustlineOutput{}, fmt.Errorf("Balance is negative (%d) for trustline (account is %s and asset is %s)", outputBalance, outputAccountID, asset.ToAsset().StringCanonical())
-	}
-
-	outputLimit := int64(trustEntry.Limit)
-	if outputLimit < 0 {
-		return TrustlineOutput{}, fmt.Errorf("Limit is negative (%d) for trustline (account is %s and asset is %s)", outputLimit, outputAccountID, asset.ToAsset().StringCanonical())
-	}
-
-	//The V1 struct is the first version of the extender from trustlineEntry. It contains information on liabilities, and in the future
-	//more extensions may contain extra information
-	trustlineExtensionInfo, V1Found := trustEntry.Ext.GetV1()
-	var outputBuyingLiabilities, outputSellingLiabilities int64
-	if V1Found {
-		liabilities := trustlineExtensionInfo.Liabilities
-		outputBuyingLiabilities, outputSellingLiabilities = int64(liabilities.Buying), int64(liabilities.Selling)
-		if outputBuyingLiabilities < 0 {
-			return TrustlineOutput{}, fmt.Errorf("The buying liabilities count is negative (%d) for trustline (account is %s and asset is %s)", outputBuyingLiabilities, outputAccountID, asset.ToAsset().StringCanonical())
-		}
-
-		if outputSellingLiabilities < 0 {
-			return TrustlineOutput{}, fmt.Errorf("The selling liabilities count is negative (%d) for trustline (account is %s and asset is %s)", outputSellingLiabilities, outputAccountID, asset.ToAsset().StringCanonical())
+	if asset.Type == xdr.AssetTypeAssetTypePoolShare {
+		poolID = PoolIDToString(trustEntry.Asset.MustLiquidityPoolId())
+	} else {
+		if err = asset.Extract(&assetType, &outputAssetCode, &outputAssetIssuer); err != nil {
+			return TrustlineOutput{}, errors.Wrap(err, fmt.Sprintf("could not parse asset for trustline with account %s", outputAccountID))
 		}
 	}
 
-	outputFlags := uint32(trustEntry.Flags)
-
-	outputLastModifiedLedger := uint32(ledgerEntry.LastModifiedLedgerSeq)
+	liabilities := trustEntry.Liabilities()
 
 	transformedTrustline := TrustlineOutput{
 		LedgerKey:          outputLedgerKey,
 		AccountID:          outputAccountID,
-		AssetType:          outputAssetType,
+		AssetType:          int32(asset.Type),
 		AssetCode:          outputAssetCode,
 		AssetIssuer:        outputAssetIssuer,
-		Balance:            outputBalance,
-		TrustlineLimit:     outputLimit,
-		BuyingLiabilities:  outputBuyingLiabilities,
-		SellingLiabilities: outputSellingLiabilities,
-		Flags:              outputFlags,
-		LastModifiedLedger: outputLastModifiedLedger,
+		Balance:            int64(trustEntry.Balance),
+		TrustlineLimit:     int64(trustEntry.Limit),
+		LiquidityPoolID:    poolID,
+		BuyingLiabilities:  int64(liabilities.Buying),
+		SellingLiabilities: int64(liabilities.Selling),
+		Flags:              uint32(trustEntry.Flags),
+		LastModifiedLedger: uint32(ledgerEntry.LastModifiedLedgerSeq),
+		Sponsor:            ledgerEntrySponsorToNullString(ledgerEntry),
 		Deleted:            outputDeleted,
 	}
 
@@ -105,4 +82,16 @@ func trustLineEntryToLedgerKeyString(trustLine xdr.TrustLineEntry) (string, erro
 	}
 
 	return base64.StdEncoding.EncodeToString(key), nil
+
+}
+
+func ledgerEntrySponsorToNullString(entry xdr.LedgerEntry) null.String {
+	sponsoringID := entry.SponsoringID()
+
+	var sponsor null.String
+	if sponsoringID != nil {
+		sponsor.SetValid((*sponsoringID).Address())
+	}
+
+	return sponsor
 }


### PR DESCRIPTION
#### Overview
This change adds TrustLine entries for Liquidity Pools. When Protocol 18 is released, a new `TrustLineAsset` which will correspond to Liquidity Pools. The TrustLine for the pools will tie to the `PoolID` instead of the `Asset` since the pools have asset pairs. 

**Changes**
* add a new field, `liqudiity_pool_id` to the `trust_lines` output 
* add missing field, `sponsor` to `trust_lines` (missed from earlier protocol
* simplify the `TransformTrustLine` code to use the xdr method `liabilities` instead of custom parsing
* add unit test for liquidity pool trustline 

This PR does not merge into the master branch, but merges into the major release branch, `amm`, which is scheduled for a release closer to the Protocol 18 release date.

Closes [#187](https://github.com/stellar/hubble/issues/187)