### PR TITLE
Bug Fix: Failed Create Accounts Error

### DIFF
--- a/internal/transform/operation.go
+++ b/internal/transform/operation.go
@@ -237,12 +237,12 @@ func extractOperationDetails(operation xdr.Operation, transaction ingest.LedgerT
 	details := map[string]interface{}{}
 	sourceAccount := getOperationSourceAccount(operation, transaction)
 	operationType := operation.Body.Type
-	allOperationResults, ok := transaction.Result.OperationResults()
-	if !ok {
-		return details, fmt.Errorf("Could not access any results for this transaction")
-	}
+	// allOperationResults, ok := transaction.Result.OperationResults()
+	// if !ok {
+	// 	return details, fmt.Errorf("Could not access any results for this transaction")
+	// }
 
-	currentOperationResult := allOperationResults[operationIndex]
+	// currentOperationResult := allOperationResults[operationIndex]
 	switch operationType {
 	case xdr.OperationTypeCreateAccount:
 		op, ok := operation.Body.GetCreateAccountOp()
@@ -279,6 +279,13 @@ func extractOperationDetails(operation xdr.Operation, transaction ingest.LedgerT
 			return details, fmt.Errorf("Could not access PathPaymentStrictReceive info for this operation (index %d)", operationIndex)
 		}
 
+		allOperationResults, ok := transaction.Result.OperationResults()
+		if !ok {
+			return details, fmt.Errorf("Could not access any results for this transaction")
+		}
+
+		currentOperationResult := allOperationResults[operationIndex]
+
 		if err := addAccountAndMuxedAccountDetails(details, sourceAccount, "from"); err != nil {
 			return details, err
 		}
@@ -314,6 +321,13 @@ func extractOperationDetails(operation xdr.Operation, transaction ingest.LedgerT
 		if !ok {
 			return details, fmt.Errorf("Could not access PathPaymentStrictSend info for this operation (index %d)", operationIndex)
 		}
+
+		allOperationResults, ok := transaction.Result.OperationResults()
+		if !ok {
+			return details, fmt.Errorf("Could not access any results for this transaction")
+		}
+
+		currentOperationResult := allOperationResults[operationIndex]
 
 		if err := addAccountAndMuxedAccountDetails(details, sourceAccount, "from"); err != nil {
 			return details, err

--- a/internal/transform/operation.go
+++ b/internal/transform/operation.go
@@ -237,12 +237,7 @@ func extractOperationDetails(operation xdr.Operation, transaction ingest.LedgerT
 	details := map[string]interface{}{}
 	sourceAccount := getOperationSourceAccount(operation, transaction)
 	operationType := operation.Body.Type
-	// allOperationResults, ok := transaction.Result.OperationResults()
-	// if !ok {
-	// 	return details, fmt.Errorf("Could not access any results for this transaction")
-	// }
 
-	// currentOperationResult := allOperationResults[operationIndex]
 	switch operationType {
 	case xdr.OperationTypeCreateAccount:
 		op, ok := operation.Body.GetCreateAccountOp()


### PR DESCRIPTION
### Bug Overview

The operations code is unable to parse `CreateAccount` failed operations, or `CreateAccount` transactions with a failed result code. The reason being is that the `OperationResults` returns a `notok` boolean for failed `CreateAccount` operations. The exception handling will catch these failed operations before the code is able to parse the valid data.

When running the `export_operations` ETL, this operation will be skipped and logged as a failed transform: 
```
Could not access any results for this transaction.
{"attempted_transforms": 5, "failed_transforms": 1, "successful_transforms": 4}
```

### Bug Fix

Move the `OperationResults` code to the operations that require the field (`PathPaymentStrictSend` and `PathPaymentStrictReceive`). That field is unnecessary for all remaining operations. This ensures that the code is not escaped prior to parsing failed operation data for other operation types.