### PR TITLE
Patch Path Payments Operations

### DIFF
--- a/internal/transform/operation.go
+++ b/internal/transform/operation.go
@@ -274,13 +274,6 @@ func extractOperationDetails(operation xdr.Operation, transaction ingest.LedgerT
 			return details, fmt.Errorf("Could not access PathPaymentStrictReceive info for this operation (index %d)", operationIndex)
 		}
 
-		allOperationResults, ok := transaction.Result.OperationResults()
-		if !ok {
-			return details, fmt.Errorf("Could not access any results for this transaction")
-		}
-
-		currentOperationResult := allOperationResults[operationIndex]
-
 		if err := addAccountAndMuxedAccountDetails(details, sourceAccount, "from"); err != nil {
 			return details, err
 		}
@@ -298,6 +291,11 @@ func extractOperationDetails(operation xdr.Operation, transaction ingest.LedgerT
 		}
 
 		if transaction.Result.Successful() {
+			allOperationResults, ok := transaction.Result.OperationResults()
+			if !ok {
+				return details, fmt.Errorf("Could not access any results for this transaction")
+			}
+			currentOperationResult := allOperationResults[operationIndex]
 			resultBody, ok := currentOperationResult.GetTr()
 			if !ok {
 				return details, fmt.Errorf("Could not access result body for this operation (index %d)", operationIndex)
@@ -317,13 +315,6 @@ func extractOperationDetails(operation xdr.Operation, transaction ingest.LedgerT
 			return details, fmt.Errorf("Could not access PathPaymentStrictSend info for this operation (index %d)", operationIndex)
 		}
 
-		allOperationResults, ok := transaction.Result.OperationResults()
-		if !ok {
-			return details, fmt.Errorf("Could not access any results for this transaction")
-		}
-
-		currentOperationResult := allOperationResults[operationIndex]
-
 		if err := addAccountAndMuxedAccountDetails(details, sourceAccount, "from"); err != nil {
 			return details, err
 		}
@@ -341,6 +332,11 @@ func extractOperationDetails(operation xdr.Operation, transaction ingest.LedgerT
 		}
 
 		if transaction.Result.Successful() {
+			allOperationResults, ok := transaction.Result.OperationResults()
+			if !ok {
+				return details, fmt.Errorf("Could not access any results for this transaction")
+			}
+			currentOperationResult := allOperationResults[operationIndex]
 			resultBody, ok := currentOperationResult.GetTr()
 			if !ok {
 				return details, fmt.Errorf("Could not access result body for this operation (index %d)", operationIndex)


### PR DESCRIPTION
The `stellar-etl` code is still dropping certain failed operations, `PathPaymentStrictSend` and `PathPaymentStrictReceive`. This is happening because only successful transaction results will return `ok` for `OperationResults()`. If the transaction failed, there are no results and the method returns not ok. 

In order to still parse failed transactions, it is necessary to move the `OperationResults()` method into an `if` statement that filters for _only_ successful transactions.