### PR TITLE
Remove check for trades with 0 selling and buying amounts.

### DIFF
--- a/cmd/export_trades.go
+++ b/cmd/export_trades.go
@@ -37,7 +37,7 @@ var tradesCmd = &cobra.Command{
 			trades, err := transform.TransformTrade(tradeInput.OperationIndex, tradeInput.OperationHistoryID, tradeInput.Transaction, tradeInput.CloseTime)
 			if err != nil {
 				parsedID := toid.Parse(tradeInput.OperationHistoryID)
-				cmdLogger.LogError(fmt.Errorf("from ledger %d, transaction %d, operation %d", parsedID.LedgerSequence, parsedID.TransactionOrder, parsedID.OperationOrder))
+				cmdLogger.LogError(fmt.Errorf("from ledger %d, transaction %d, operation %d: %v", parsedID.LedgerSequence, parsedID.TransactionOrder, parsedID.OperationOrder, err))
 				numFailures += 1
 				continue
 			}

--- a/cmd/export_trades_test.go
+++ b/cmd/export_trades_test.go
@@ -8,25 +8,25 @@ func TestExportTrades(t *testing.T) {
 	tests := []cliTest{
 		{
 			name:    "trades from one ledger",
-			args:    []string{"export_trades", "-s", "28770265", "-e", "28770265", "-o", gotTestDir(t, ".txt")},
+			args:    []string{"export_trades", "-s", "28770265", "-e", "28770265", "-o", gotTestDir(t, "one_ledger_trades.txt")},
 			golden:  "one_ledger_trades.golden",
 			wantErr: nil,
 		},
 		{
 			name:    "trades from 10 ledgers",
-			args:    []string{"export_trades", "-s", "28770265", "-e", "28770275", "-o", gotTestDir(t, ".txt")},
+			args:    []string{"export_trades", "-s", "28770265", "-e", "28770275", "-o", gotTestDir(t, "10_ledgers_trades.txt")},
 			golden:  "10_ledgers_trades.golden",
 			wantErr: nil,
 		},
 		{
 			name:    "range too large",
-			args:    []string{"export_trades", "-s", "28770265", "-e", "28770275", "-l", "5", "-o", gotTestDir(t, ".txt")},
+			args:    []string{"export_trades", "-s", "28770265", "-e", "28770275", "-l", "5", "-o", gotTestDir(t, "large_range_trades.txt")},
 			golden:  "large_range_trades.golden",
 			wantErr: nil,
 		},
 		{
 			name:    "ledger with no trades",
-			args:    []string{"export_trades", "-s", "10363513", "-e", "10363513", "-o", gotTestDir(t, ".txt")},
+			args:    []string{"export_trades", "-s", "10363513", "-e", "10363513", "-o", gotTestDir(t, "ledger_no_trades.txt")},
 			golden:  "ledger_no_trades.golden",
 			wantErr: nil,
 		},

--- a/internal/input/operations.go
+++ b/internal/input/operations.go
@@ -36,6 +36,9 @@ func GetOperations(start, end uint32, limit int64, env utils.EnvironmentDetails)
 			Strict:             true,
 		},
 	)
+	if err != nil {
+		return []OperationTransformInput{}, err
+	}
 
 	backend, err := ledgerbackend.NewCaptive(
 		ledgerbackend.CaptiveCoreConfig{

--- a/internal/transform/trade.go
+++ b/internal/transform/trade.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/stellar/go/ingest"
+	"github.com/stellar/go/support/log"
 	"github.com/stellar/go/xdr"
 	"github.com/stellar/stellar-etl/internal/toid"
 	"github.com/stellar/stellar-etl/internal/utils"
@@ -61,7 +62,8 @@ func TransformTrade(operationIndex int32, operationID int64, transaction ingest.
 		}
 
 		if outputSellingAmount == 0 && outputBuyingAmount == 0 {
-			return []TradeOutput{}, fmt.Errorf("Both Selling and Buying amount are 0 for operation at index %d", operationIndex)
+			log.Debugf("Both Selling and Buying amount are 0 for operation at index %d", operationIndex)
+			return []TradeOutput{}, nil
 		}
 
 		// Final price should be buy / sell


### PR DESCRIPTION
This is causing spammy logs/failures for `export_trade` jobs. `stellar-core` garbage collects trades with 0 values.