### PR TITLE
Add sponsorship to offers and accounts

### DIFF
--- a/internal/transform/account.go
+++ b/internal/transform/account.go
@@ -88,6 +88,9 @@ func TransformAccount(ledgerChange ingest.Change) (AccountOutput, error) {
 		ThresholdMedium:      outputThreshMed,
 		ThresholdHigh:        outputThreshHigh,
 		LastModifiedLedger:   outputLastModifiedLedger,
+		Sponsor:              ledgerEntrySponsorToNullString(ledgerEntry),
+		NumSponsored:         uint32(accountEntry.NumSponsored()),
+		NumSponsoring:        uint32(accountEntry.NumSponsoring()),
 		LedgerEntryChange:    uint32(changeType),
 		Deleted:              outputDeleted,
 	}

--- a/internal/transform/account_test.go
+++ b/internal/transform/account_test.go
@@ -1,9 +1,11 @@
 package transform
 
 import (
+	"database/sql"
 	"fmt"
 	"testing"
 
+	"github.com/guregu/null"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/stellar/go/ingest"
@@ -102,6 +104,7 @@ func wrapAccountEntry(accountEntry xdr.AccountEntry, lastModified int) ingest.Ch
 }
 
 func makeAccountTestInput() ingest.Change {
+
 	ledgerEntry := xdr.LedgerEntry{
 		LastModifiedLedgerSeq: 30705278,
 		Data: xdr.LedgerEntryData{
@@ -122,8 +125,21 @@ func makeAccountTestInput() ingest.Change {
 							Buying:  1000,
 							Selling: 1500,
 						},
+						Ext: xdr.AccountEntryExtensionV1Ext{
+							V: 2,
+							V2: &xdr.AccountEntryExtensionV2{
+								NumSponsored:  3,
+								NumSponsoring: 1,
+							},
+						},
 					},
 				},
+			},
+		},
+		Ext: xdr.LedgerEntryExt{
+			V: 1,
+			V1: &xdr.LedgerEntryExtensionV1{
+				SponsoringId: &testAccount3ID,
 			},
 		},
 	}
@@ -149,8 +165,16 @@ func makeAccountTestOutput() AccountOutput {
 		ThresholdLow:         1,
 		ThresholdMedium:      3,
 		ThresholdHigh:        5,
-		LastModifiedLedger:   30705278,
-		LedgerEntryChange:    2,
-		Deleted:              true,
+		Sponsor: null.String{
+			NullString: sql.NullString{
+				String: testAccount3Address,
+				Valid:  true,
+			},
+		},
+		NumSponsored:       3,
+		NumSponsoring:      1,
+		LastModifiedLedger: 30705278,
+		LedgerEntryChange:  2,
+		Deleted:            true,
 	}
 }

--- a/internal/transform/offer.go
+++ b/internal/transform/offer.go
@@ -71,8 +71,12 @@ func TransformOffer(ledgerChange ingest.Change) (OfferOutput, error) {
 	transformedOffer := OfferOutput{
 		SellerID:           outputSellerID,
 		OfferID:            outputOfferID,
-		SellingAsset:       outputSellingAsset.AssetID,
-		BuyingAsset:        outputBuyingAsset.AssetID,
+		SellingAssetType:   outputSellingAsset.AssetType,
+		SellingAssetCode:   outputSellingAsset.AssetCode,
+		SellingAssetIssuer: outputSellingAsset.AssetIssuer,
+		BuyingAssetType:    outputBuyingAsset.AssetType,
+		BuyingAssetCode:    outputBuyingAsset.AssetCode,
+		BuyingAssetIssuer:  outputBuyingAsset.AssetIssuer,
 		Amount:             utils.ConvertStroopValueToReal(outputAmount),
 		PriceN:             outputPriceN,
 		PriceD:             outputPriceD,
@@ -81,6 +85,7 @@ func TransformOffer(ledgerChange ingest.Change) (OfferOutput, error) {
 		LastModifiedLedger: outputLastModifiedLedger,
 		LedgerEntryChange:  uint32(changeType),
 		Deleted:            outputDeleted,
+		Sponsor:            ledgerEntrySponsorToNullString(ledgerEntry),
 	}
 	return transformedOffer, nil
 }

--- a/internal/transform/offer_test.go
+++ b/internal/transform/offer_test.go
@@ -1,9 +1,11 @@
 package transform
 
 import (
+	"database/sql"
 	"fmt"
 	"testing"
 
+	"github.com/guregu/null"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/stellar/go/ingest"
@@ -124,6 +126,12 @@ func makeOfferTestInput() (ledgerChange ingest.Change, err error) {
 					Flags: 2,
 				},
 			},
+			Ext: xdr.LedgerEntryExt{
+				V: 1,
+				V1: &xdr.LedgerEntryExtensionV1{
+					SponsoringId: &testAccount3ID,
+				},
+			},
 		},
 		Post: nil,
 	}
@@ -134,8 +142,12 @@ func makeOfferTestOutput() OfferOutput {
 	return OfferOutput{
 		SellerID:           testAccount1Address,
 		OfferID:            260678439,
-		SellingAsset:       12638146518625398189,
-		BuyingAsset:        13488700931717487949,
+		SellingAssetType:   "native",
+		SellingAssetCode:   "",
+		SellingAssetIssuer: "",
+		BuyingAssetType:    "credit_alphanum4",
+		BuyingAssetCode:    "ETH",
+		BuyingAssetIssuer:  testAccount3Address,
 		Amount:             262.8450327,
 		PriceN:             920936891,
 		PriceD:             1790879058,
@@ -144,5 +156,11 @@ func makeOfferTestOutput() OfferOutput {
 		LastModifiedLedger: 30715263,
 		LedgerEntryChange:  2,
 		Deleted:            true,
+		Sponsor: null.String{
+			NullString: sql.NullString{
+				String: testAccount3Address,
+				Valid:  true,
+			},
+		},
 	}
 }

--- a/internal/transform/schema.go
+++ b/internal/transform/schema.go
@@ -53,22 +53,25 @@ type TransactionOutput struct {
 
 // AccountOutput is a representation of an account that aligns with the BigQuery table accounts
 type AccountOutput struct {
-	AccountID            string  `json:"account_id"` // account address
-	Balance              float64 `json:"balance"`
-	BuyingLiabilities    float64 `json:"buying_liabilities"`
-	SellingLiabilities   float64 `json:"selling_liabilities"`
-	SequenceNumber       int64   `json:"sequence_number"`
-	NumSubentries        uint32  `json:"num_subentries"`
-	InflationDestination string  `json:"inflation_destination"`
-	Flags                uint32  `json:"flags"`
-	HomeDomain           string  `json:"home_domain"`
-	MasterWeight         int32   `json:"master_weight"`
-	ThresholdLow         int32   `json:"threshold_low"`
-	ThresholdMedium      int32   `json:"threshold_medium"`
-	ThresholdHigh        int32   `json:"threshold_high"`
-	LastModifiedLedger   uint32  `json:"last_modified_ledger"`
-	LedgerEntryChange    uint32  `json:"ledger_entry_change"`
-	Deleted              bool    `json:"deleted"`
+	AccountID            string      `json:"account_id"` // account address
+	Balance              float64     `json:"balance"`
+	BuyingLiabilities    float64     `json:"buying_liabilities"`
+	SellingLiabilities   float64     `json:"selling_liabilities"`
+	SequenceNumber       int64       `json:"sequence_number"`
+	NumSubentries        uint32      `json:"num_subentries"`
+	InflationDestination string      `json:"inflation_destination"`
+	Flags                uint32      `json:"flags"`
+	HomeDomain           string      `json:"home_domain"`
+	MasterWeight         int32       `json:"master_weight"`
+	ThresholdLow         int32       `json:"threshold_low"`
+	ThresholdMedium      int32       `json:"threshold_medium"`
+	ThresholdHigh        int32       `json:"threshold_high"`
+	Sponsor              null.String `json:"sponsor"`
+	NumSponsored         uint32      `json:"num_sponsored"`
+	NumSponsoring        uint32      `json:"num_sponsoring"`
+	LastModifiedLedger   uint32      `json:"last_modified_ledger"`
+	LedgerEntryChange    uint32      `json:"ledger_entry_change"`
+	Deleted              bool        `json:"deleted"`
 }
 
 // AccountSignerOutput is a representation of an account signer that aligns with the BigQuery table account_signers
@@ -188,18 +191,23 @@ type TrustlineOutput struct {
 
 // OfferOutput is a representation of an offer that aligns with the BigQuery table offers
 type OfferOutput struct {
-	SellerID           string  `json:"seller_id"` // Account address of the seller
-	OfferID            int64   `json:"offer_id"`
-	SellingAsset       uint64  `json:"selling_asset"`
-	BuyingAsset        uint64  `json:"buying_asset"`
-	Amount             float64 `json:"amount"`
-	PriceN             int32   `json:"pricen"`
-	PriceD             int32   `json:"priced"`
-	Price              float64 `json:"price"`
-	Flags              uint32  `json:"flags"`
-	LastModifiedLedger uint32  `json:"last_modified_ledger"`
-	LedgerEntryChange  uint32  `json:"ledger_entry_change"`
-	Deleted            bool    `json:"deleted"`
+	SellerID           string      `json:"seller_id"` // Account address of the seller
+	OfferID            int64       `json:"offer_id"`
+	SellingAssetType   string      `json:"selling_asset_type"`
+	SellingAssetCode   string      `json:"selling_asset_code"`
+	SellingAssetIssuer string      `json:"selling_asset_issuer"`
+	BuyingAssetType    string      `json:"buying_asset_type"`
+	BuyingAssetCode    string      `json:"buying_asset_code"`
+	BuyingAssetIssuer  string      `json:"buying_asset_issuer"`
+	Amount             float64     `json:"amount"`
+	PriceN             int32       `json:"pricen"`
+	PriceD             int32       `json:"priced"`
+	Price              float64     `json:"price"`
+	Flags              uint32      `json:"flags"`
+	LastModifiedLedger uint32      `json:"last_modified_ledger"`
+	LedgerEntryChange  uint32      `json:"ledger_entry_change"`
+	Deleted            bool        `json:"deleted"`
+	Sponsor            null.String `json:"sponsor"`
 }
 
 // TradeOutput is a representation of a trade that aligns with the BigQuery table history_trades


### PR DESCRIPTION
Sponsorship was missing from two state tables. The following missing fields were added: 

**`accounts`**
* `sponsor`
* `num_sponsored`
* `num_sponsoring`


**`offers`**
* `sponsor`

Associated unit tests were updated for both to include `sponsor` in the `LedgerEntry` XDR.

Additionally, I decided to change the schema of the `offers` table to make the user experience better. Today, the buying and selling assets are reported by their id, forcing you to join to the `history_assets` table. I decided to normalize those fields:
`buying_asset_id` --> updated to include asset_type, asset_code and asset_issuer
`selling_asset_id` --> updated to include asset_type, asset_code and asset_issuer

This makes the table more readable and reduces the number of joins necessary.
