### PR TITLE
Fix claimable balance id 

### DIFF
--- a/internal/transform/claimable_balance.go
+++ b/internal/transform/claimable_balance.go
@@ -2,6 +2,7 @@ package transform
 
 import (
 	"fmt"
+
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/xdr"
 	"github.com/stellar/stellar-etl/internal/utils"
@@ -30,9 +31,9 @@ func TransformClaimableBalance(ledgerChange ingest.Change) (ClaimableBalanceOutp
 	if !balanceFound {
 		return ClaimableBalanceOutput{}, fmt.Errorf("could not extract claimable balance data from ledger entry; actual type is %s", ledgerEntry.Data.Type)
 	}
-	outputId, foundId := balanceEntry.BalanceId.GetV0()
-	if !foundId {
-		return ClaimableBalanceOutput{}, fmt.Errorf("could not extract claimable balance id from ledger entry: %v", balanceEntry.BalanceId)
+	balanceID, err := xdr.MarshalHex(balanceEntry.BalanceId)
+	if err != nil {
+		return ClaimableBalanceOutput{}, fmt.Errorf("Invalid balanceId in op: %d", uint32(ledgerEntry.LastModifiedLedgerSeq))
 	}
 	outputFlags := uint32(balanceEntry.Flags())
 	outputAsset, err := transformSingleAsset(balanceEntry.Asset)
@@ -45,7 +46,7 @@ func TransformClaimableBalance(ledgerChange ingest.Change) (ClaimableBalanceOutp
 	outputLastModifiedLedger := uint32(ledgerEntry.LastModifiedLedgerSeq)
 
 	transformed := ClaimableBalanceOutput{
-		BalanceID:          outputId.HexString(),
+		BalanceID:          balanceID,
 		AssetCode:          outputAsset.AssetCode,
 		AssetIssuer:        outputAsset.AssetIssuer,
 		AssetType:          outputAsset.AssetType,

--- a/internal/transform/claimable_balance_test.go
+++ b/internal/transform/claimable_balance_test.go
@@ -89,7 +89,7 @@ func makeClaimableBalanceTestInput() ingest.Change {
 
 func makeClaimableBalanceTestOutput() ClaimableBalanceOutput {
 	return ClaimableBalanceOutput{
-		BalanceID: "0102030405060708090000000000000000000000000000000000000000000000",
+		BalanceID: "000000000102030405060708090000000000000000000000000000000000000000000000",
 		Claimants: []Claimant{
 			{
 				Destination: "GCEODJVUUVYVFD5KT4TOEDTMXQ76OPFOQC2EMYYMLPXQCUVPOB6XRWPQ",


### PR DESCRIPTION
Closes [#272](https://github.com/stellar/hubble/issues/272)

The `history_operations` and `claimable_balances` table report the `balance_id` differently. The `history_operations` table includes `"00000000"` to the front of the id, which is the correct way to report the id. Balance IDs were truncated  in `claimable_balances` due using the `GetV0()` method. Transformation is corrected so that both align. 