### PR TITLE
Capture all state changes

### DIFF
--- a/cmd/export_ledger_entry_changes.go
+++ b/cmd/export_ledger_entry_changes.go
@@ -31,7 +31,7 @@ be exported.`,
 		env := utils.GetEnvironmentDetails(isTest)
 
 		execPath, configPath, startNum, batchSize, outputFolder := utils.MustCoreFlags(cmd.Flags(), cmdLogger)
-		exportAccounts, exportOffers, exportTrustlines, exportPools := utils.MustExportTypeFlags(cmd.Flags(), cmdLogger)
+		exportAccounts, exportOffers, exportTrustlines, exportPools, exportBalances := utils.MustExportTypeFlags(cmd.Flags(), cmdLogger)
 		gcsBucket, gcpCredentials := utils.MustGcsFlags(cmd.Flags(), cmdLogger)
 
 		err := os.MkdirAll(outputFolder, os.ModePerm)
@@ -44,8 +44,8 @@ be exported.`,
 		}
 
 		// If none of the export flags are set, then we assume that everything should be exported
-		if !exportAccounts && !exportOffers && !exportTrustlines && !exportPools {
-			exportAccounts, exportOffers, exportTrustlines, exportPools = true, true, true, true
+		if !exportAccounts && !exportOffers && !exportTrustlines && !exportPools && !exportBalances {
+			exportAccounts, exportOffers, exportTrustlines, exportPools, exportBalances = true, true, true, true, true
 		}
 
 		if configPath == "" && endNum == 0 {

--- a/internal/input/changes.go
+++ b/internal/input/changes.go
@@ -104,6 +104,7 @@ func extractBatch(
 			}
 
 			for {
+
 				change, err := changeReader.Read()
 				if err == io.EOF {
 					break
@@ -118,15 +119,20 @@ func extractBatch(
 					logger.Infof("change type: %v not tracked", change.Type)
 				} else {
 					cache.AddChange(change)
+
 				}
+
 			}
 
 			changeReader.Close()
+
 			seq++
 		}
 
 		for dataType, compactor := range changeCompactors {
-			changes[dataType] = compactor.GetChanges()
+			for _, change := range compactor.GetChanges() {
+				changes[dataType] = append(changes[dataType], change)
+			}
 		}
 
 	}

--- a/internal/input/changes.go
+++ b/internal/input/changes.go
@@ -104,7 +104,6 @@ func extractBatch(
 			}
 
 			for {
-
 				change, err := changeReader.Read()
 				if err == io.EOF {
 					break
@@ -119,13 +118,10 @@ func extractBatch(
 					logger.Infof("change type: %v not tracked", change.Type)
 				} else {
 					cache.AddChange(change)
-
 				}
-
 			}
 
 			changeReader.Close()
-
 			seq++
 		}
 

--- a/internal/utils/main.go
+++ b/internal/utils/main.go
@@ -226,6 +226,7 @@ func AddExportTypeFlags(flags *pflag.FlagSet) {
 	flags.BoolP("export-trustlines", "t", false, "set in order to export trustline changes")
 	flags.BoolP("export-offers", "f", false, "set in order to export offer changes")
 	flags.BoolP("export-pools", "p", false, "set in order to export liquidity pool changes")
+	flags.BoolP("export-balances", "l", false, "set in order to export claimable balance changes")
 }
 
 // MustCommonFlags gets the values of the the flags common to all commands: end-ledger and strict-export. If any do not exist, it stops the program fatally using the logger
@@ -326,7 +327,7 @@ func MustCoreFlags(flags *pflag.FlagSet, logger *EtlLogger) (execPath, configPat
 }
 
 // MustExportTypeFlags gets the values for the export-accounts, export-offers, and export-trustlines flags. If any do not exist, it stops the program fatally using the logger
-func MustExportTypeFlags(flags *pflag.FlagSet, logger *EtlLogger) (exportAccounts, exportOffers, exportTrustlines, exportPools bool) {
+func MustExportTypeFlags(flags *pflag.FlagSet, logger *EtlLogger) (exportAccounts, exportOffers, exportTrustlines, exportPools, exportBalances bool) {
 	exportAccounts, err := flags.GetBool("export-accounts")
 	if err != nil {
 		logger.Fatal("could not get export accounts flag: ", err)
@@ -345,6 +346,11 @@ func MustExportTypeFlags(flags *pflag.FlagSet, logger *EtlLogger) (exportAccount
 	exportPools, err = flags.GetBool("export-pools")
 	if err != nil {
 		logger.Fatal("could not export liquidity pools flag: ", err)
+	}
+
+	exportBalances, err = flags.GetBool("export-balances")
+	if err != nil {
+		logger.Fatal("could not export claimable balances flag: ", err)
 	}
 
 	return


### PR DESCRIPTION
State tables were only capturing changes to state occurring in the _last_ ledger within block range. This was due to us assigning the `changeCompactor` the last set of changes (last ledger) instead of _appending_ the change set. 

PR also adds `--export-balances` as an option from command line to be used when debugging.