### PR TITLE
Remove duplicate processed ledgers from state tables

### DIFF
--- a/cmd/export_ledger_entry_changes.go
+++ b/cmd/export_ledger_entry_changes.go
@@ -62,9 +62,6 @@ be exported.`,
 			cmdLogger.Fatal("could not get absolute filepath for the config file: ", err)
 		}
 
-		if endNum != 0 {
-			endNum = endNum + 1
-		}
 		core, err := input.PrepareCaptiveCore(execPath, configPath, startNum, endNum, env)
 		if err != nil {
 			cmdLogger.Fatal("error creating a prepared captive core instance: ", err)

--- a/internal/input/changes.go
+++ b/internal/input/changes.go
@@ -146,6 +146,9 @@ func StreamChanges(core *ledgerbackend.CaptiveStellarCore, start, end, batchSize
 	batchStart := start
 	batchEnd := uint32(math.Min(float64(batchStart+batchSize), float64(end)))
 	for batchStart < batchEnd {
+		if batchEnd < end {
+			batchEnd = uint32(batchEnd - 1)
+		}
 		batch := extractBatch(batchStart, batchEnd, core, env, logger)
 		changeChannel <- batch
 		batchStart = uint32(math.Min(float64(batchEnd), float64(end)))


### PR DESCRIPTION
The state table processors in Hubble were introducing duplicate records to the tables for two reasons: 
1. Given a batch range, the `export_ledger_entry_changes` code incremented the `end-ledger` by 1, which introduced a 1-ledger overlap between end ledger values and start ledger values for the following batch. 
2. The `input/changes.go` code divided up large batches into checkpoint-sized batches. These checkpoint sized definitions processed ledger inclusive of both start/end ledger ranges. This would double process end ledgers as the following batch's start ledger.

Changes adjust the processors to be exclusive of end ledgers so that the range processes each ledger only once.

Closes [#271](https://github.com/stellar/hubble/issues/271)