### PR TITLE
Adjust batch starts and filenames

### DIFF
--- a/cmd/export_ledger_entry_changes.go
+++ b/cmd/export_ledger_entry_changes.go
@@ -180,7 +180,10 @@ func exportTransformedData(
 	extra map[string]string) error {
 
 	for resource, output := range transformedOutput {
-		path := filepath.Join(folderPath, exportFilename(start, end, resource))
+		// Filenames are typically exclusive of end point. This processor
+		// is different and we have to increment by 1 since the end batch number
+		// is included in this filename.
+		path := filepath.Join(folderPath, exportFilename(start, end+1, resource))
 		outFile := mustOutFile(path)
 		for _, o := range output {
 			_, err := exportEntry(o, outFile, extra)

--- a/internal/input/changes.go
+++ b/internal/input/changes.go
@@ -155,7 +155,9 @@ func StreamChanges(core *ledgerbackend.CaptiveStellarCore, start, end, batchSize
 		}
 		batch := ExtractBatch(batchStart, batchEnd, core, env, logger)
 		changeChannel <- batch
-		batchStart = uint32(math.Min(float64(batchEnd), float64(end)))
+		// batchStart and batchEnd should not overlap
+		// overlapping batches causes duplicate record loads
+		batchStart = uint32(math.Min(float64(batchEnd), float64(end)) + 1)
 		batchEnd = uint32(math.Min(float64(batchStart+batchSize), float64(end)))
 	}
 	close(changeChannel)

--- a/internal/input/changes_test.go
+++ b/internal/input/changes_test.go
@@ -1,11 +1,12 @@
 package input
 
 import (
+	"testing"
+
 	"github.com/stellar/go/ingest/ledgerbackend"
 	"github.com/stellar/go/support/log"
 	"github.com/stellar/stellar-etl/internal/utils"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/xdr"
@@ -168,7 +169,7 @@ func TestStreamChangesBatchNumbers(t *testing.T) {
 					batchRange{
 						batchStart: 1, batchEnd: 64,
 					}, batchRange{
-						batchStart: 64, batchEnd: 66,
+						batchStart: 65, batchEnd: 66,
 					},
 				},
 			},
@@ -181,7 +182,7 @@ func TestStreamChangesBatchNumbers(t *testing.T) {
 						batchStart: 1, batchEnd: 64,
 					},
 					batchRange{
-						batchStart: 64, batchEnd: 128,
+						batchStart: 65, batchEnd: 128,
 					},
 				},
 			},


### PR DESCRIPTION
The batch start needed to be incremented by 1 so that ledger entry ranges did not overlap. The overlapping was still causing duplicates in the final dataset.

Adjustments also made to the filenames since the `exportFilename` method decrements the ledger range by 1. Incremented the end input by 1 so that we preserve the correct range in the filename.