### PR TITLE
Add new fields history_transactions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ docker-build:
 
 docker-push:
 	$(SUDO) docker push $(ETLHASH)
-	$(SUOD) docker push stellar/stellar-etl:latest
+	$(SUDO) docker push stellar/stellar-etl:latest

--- a/cmd/export_transactions.go
+++ b/cmd/export_transactions.go
@@ -20,8 +20,9 @@ var transactionsCmd = &cobra.Command{
 		cmdLogger.StrictExport = strictExport
 		startNum, path, limit := utils.MustArchiveFlags(cmd.Flags(), cmdLogger)
 		gcsBucket, gcpCredentials := utils.MustGcsFlags(cmd.Flags(), cmdLogger)
+		env := utils.GetEnvironmentDetails(isTest)
 
-		transactions, err := input.GetTransactions(startNum, endNum, limit, isTest)
+		transactions, err := input.GetTransactions(startNum, endNum, limit, env)
 		if err != nil {
 			cmdLogger.Fatal("could not read transactions: ", err)
 		}
@@ -40,7 +41,7 @@ var transactionsCmd = &cobra.Command{
 
 			numBytes, err := exportEntry(transformed, outFile, extra)
 			if err != nil {
-				cmdLogger.LogError(err)
+				cmdLogger.LogError(fmt.Errorf("could not export transaction: %v", err))
 				numFailures += 1
 				continue
 			}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,16 +1,25 @@
-FROM docker.io/golang:1.18
+# docker image stellar/stellar-core version 19, pinned by sha digest
+FROM stellar/stellar-core@sha256:b4e85991ea5a72667a147e2d49018269c252c096dfc2a845d13142e615ea4dd3
 
-COPY . /etl
-WORKDIR /etl
+# define gopath and path
+ENV GOPATH /home/stellar/go
+ENV PATH /usr/local/go/bin:/home/stellar/go/bin:$PATH
+
+WORKDIR /tmp
+
+# download, validate and extract go binaries
+RUN wget https://go.dev/dl/go1.18.5.linux-amd64.tar.gz
+RUN echo '9e5de37f9c49942c601b191ac5fba404b868bfc21d446d6960acc12283d6e5f2 go1.18.5.linux-amd64.tar.gz' > go1.18.5.linux-amd64.tar.gz.checksum
+RUN sha256sum -c go1.18.5.linux-amd64.tar.gz.checksum && tar -C /usr/local -xvf go1.18.5.linux-amd64.tar.gz
+
+# install stellar-etl as 'stellar' user to avoid docker shim errors
+USER stellar
+WORKDIR /home/stellar/etl
+
+COPY . .
 RUN go install
 
-RUN apt-get -qq update
-# Needed for stellar-core
-RUN wget -qO - https://apt.stellar.org/SDF.asc | apt-key add -
-RUN echo "deb https://apt.stellar.org focal stable" | tee -a /etc/apt/sources.list.d/SDF.list
+# clear entrypoint from stellar-core image
+ENTRYPOINT []
 
-# Needed for stellar-core dependencies
-RUN echo "deb http://deb.debian.org/debian buster-backports main" | tee -a /etc/apt/sources.list.d/buster-backports.list
-
-RUN apt-get -qq update && apt-get -qq install -y stellar-core
 CMD ["stellar-etl"]

--- a/docker/stellar-core.cfg
+++ b/docker/stellar-core.cfg
@@ -1,5 +1,5 @@
 # This is an example config for setting up a Captive Core stellar-core instance
-# see https://www.stellar.org/developers/stellar-core/software/admin.html
+# see https://developers.stellar.org/docs/run-core-node/
 # for how to properly configure your environment
 
 #FAILURE_SAFETY is minimum number of nodes that are allowed to fail before you no longer have quorum

--- a/internal/input/transactions.go
+++ b/internal/input/transactions.go
@@ -17,9 +17,9 @@ type LedgerTransformInput struct {
 	LedgerHistory xdr.LedgerHeaderHistoryEntry
 }
 
-// GetTransactions returns a slice of ledger close metas for the ledgers in the provided range (inclusive on both ends)
-func GetTransactions(start, end uint32, limit int64, isTest bool) ([]LedgerTransformInput, error) {
-	env := utils.GetEnvironmentDetails(isTest)
+// GetOperations returns a slice of operations for the ledgers in the provided range (inclusive on both ends)
+func GetTransactions(start, end uint32, limit int64, env utils.EnvironmentDetails) ([]LedgerTransformInput, error) {
+	ctx := context.Background()
 	captiveCoreToml, err := ledgerbackend.NewCaptiveCoreTomlFromFile(
 		env.CoreConfig,
 		ledgerbackend.CaptiveCoreTomlParams{
@@ -46,17 +46,15 @@ func GetTransactions(start, end uint32, limit int64, isTest bool) ([]LedgerTrans
 		return []LedgerTransformInput{}, err
 	}
 
-	var txSlice []LedgerTransformInput
-	ctx := context.Background()
+	txSlice := []LedgerTransformInput{}
+	err = backend.PrepareRange(ctx, ledgerbackend.BoundedRange(start, end))
+	panicIf(err)
 	for seq := start; seq <= end; seq++ {
-		err = backend.PrepareRange(ctx, ledgerbackend.BoundedRange(start, end))
+		changeReader, err := ingest.NewLedgerChangeReader(ctx, backend, env.NetworkPassphrase, seq)
 		if err != nil {
 			return []LedgerTransformInput{}, err
 		}
-		txReader, err := ingest.NewLedgerTransactionReader(ctx, backend, env.NetworkPassphrase, seq)
-		if err != nil {
-			return []LedgerTransformInput{}, err
-		}
+		txReader := changeReader.LedgerTransactionReader
 
 		lhe := txReader.GetHeader()
 		// A negative limit value means that all input should be processed

--- a/internal/transform/schema.go
+++ b/internal/transform/schema.go
@@ -41,6 +41,10 @@ type TransactionOutput struct {
 	MaxFee                      uint32         `json:"max_fee"`
 	FeeCharged                  int64          `json:"fee_charged"`
 	OperationCount              int32          `json:"operation_count"`
+	TxEnvelope                  string         `json:"tx_envelope"`
+	TxResult                    string         `json:"tx_result"`
+	TxMeta                      string         `json:"tx_meta"`
+	TxFeeMeta                   string         `json:"tx_fee_meta"`
 	CreatedAt                   time.Time      `json:"created_at"`
 	MemoType                    string         `json:"memo_type"`
 	Memo                        string         `json:"memo"`

--- a/internal/transform/test_variables_test.go
+++ b/internal/transform/test_variables_test.go
@@ -35,6 +35,22 @@ var genericBumpOperationEnvelope = xdr.TransactionV1Envelope{
 		},
 	},
 }
+var genericBumpOperationForTransaction = xdr.Operation{
+	SourceAccount: &genericSourceAccount,
+	Body: xdr.OperationBody{
+		Type:           xdr.OperationTypeBumpSequence,
+		BumpSequenceOp: &xdr.BumpSequenceOp{},
+	},
+}
+var genericBumpOperationEnvelopeForTransaction = xdr.TransactionV1Envelope{
+	Tx: xdr.Transaction{
+		SourceAccount: genericSourceAccount,
+		Memo:          xdr.Memo{},
+		Operations: []xdr.Operation{
+			genericBumpOperationForTransaction,
+		},
+	},
+}
 var genericManageBuyOfferEnvelope = xdr.TransactionV1Envelope{
 	Tx: xdr.Transaction{
 		SourceAccount: genericSourceAccount,

--- a/internal/transform/transaction.go
+++ b/internal/transform/transaction.go
@@ -52,14 +52,17 @@ func TransformTransaction(transaction ingest.LedgerTransaction, lhe xdr.LedgerHe
 	if err != nil {
 		return TransactionOutput{}, err
 	}
+
 	outputTxResult, err := xdr.MarshalBase64(&transaction.Result.Result)
 	if err != nil {
 		return TransactionOutput{}, err
 	}
-	outputTxMeta, err := xdr.MarshalBase64(transaction.UnsafeMeta.V)
+
+	outputTxMeta, err := xdr.MarshalBase64(transaction.UnsafeMeta)
 	if err != nil {
 		return TransactionOutput{}, err
 	}
+
 	outputTxFeeMeta, err := xdr.MarshalBase64(transaction.FeeChanges)
 	if err != nil {
 		return TransactionOutput{}, err

--- a/internal/transform/transaction.go
+++ b/internal/transform/transaction.go
@@ -47,6 +47,24 @@ func TransformTransaction(transaction ingest.LedgerTransaction, lhe xdr.LedgerHe
 	}
 
 	outputOperationCount := int32(len(transaction.Envelope.Operations()))
+
+	outputTxEnvelope, err := xdr.MarshalBase64(transaction.Envelope)
+	if err != nil {
+		return TransactionOutput{}, err
+	}
+	outputTxResult, err := xdr.MarshalBase64(&transaction.Result.Result)
+	if err != nil {
+		return TransactionOutput{}, err
+	}
+	outputTxMeta, err := xdr.MarshalBase64(transaction.UnsafeMeta)
+	if err != nil {
+		return TransactionOutput{}, err
+	}
+	outputTxFeeMeta, err := xdr.MarshalBase64(transaction.FeeChanges)
+	if err != nil {
+		return TransactionOutput{}, err
+	}
+
 	outputCreatedAt, err := utils.TimePointToUTCTimeStamp(ledgerHeader.ScpValue.CloseTime)
 	if err != nil {
 		return TransactionOutput{}, fmt.Errorf("for ledger %d; transaction %d (transaction id=%d): %v", outputLedgerSequence, outputApplicationOrder, outputTransactionID, err)
@@ -120,6 +138,10 @@ func TransformTransaction(transaction ingest.LedgerTransaction, lhe xdr.LedgerHe
 		MaxFee:                      outputMaxFee,
 		FeeCharged:                  outputFeeCharged,
 		OperationCount:              outputOperationCount,
+		TxEnvelope:                  outputTxEnvelope,
+		TxResult:                    outputTxResult,
+		TxMeta:                      outputTxMeta,
+		TxFeeMeta:                   outputTxFeeMeta,
 		CreatedAt:                   outputCreatedAt,
 		MemoType:                    outputMemoType,
 		Memo:                        outputMemoContents,

--- a/internal/transform/transaction.go
+++ b/internal/transform/transaction.go
@@ -56,7 +56,7 @@ func TransformTransaction(transaction ingest.LedgerTransaction, lhe xdr.LedgerHe
 	if err != nil {
 		return TransactionOutput{}, err
 	}
-	outputTxMeta, err := xdr.MarshalBase64(transaction.UnsafeMeta)
+	outputTxMeta, err := xdr.MarshalBase64(transaction.UnsafeMeta.V)
 	if err != nil {
 		return TransactionOutput{}, err
 	}

--- a/internal/transform/transaction_test.go
+++ b/internal/transform/transaction_test.go
@@ -83,6 +83,10 @@ func makeTransactionTestOutput() (output []TransactionOutput, err error) {
 	correctTime, err := time.Parse("2006-1-2 15:04:05 MST", "2020-07-09 05:28:42 UTC")
 	output = []TransactionOutput{
 		TransactionOutput{
+			TxEnvelope:       "AAAAAgAAAACI4aa0pXFSj6qfJuIObLw/5zyugLRGYwxb7wFSr3B9eAABX5ABjydzAABBtwAAAAEAAAAAAAAAAAAAAABfBqt0AAAAAQAAABdITDVhQ2dvelFISVc3c1NjNVhkY2ZtUgAAAAABAAAAAQAAAAAcR0GXGO76pFs4y38vJVAanjnLg4emNun7zAx0pHcDGAAAAAIAAAAAAAAAAAAAAAAAAAAAAQIDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+			TxResult:         "AAAAAAAAASz/////AAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+			TxMeta:           "AAAAAQAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAwAAAAAAAAAFAQIDBAUGBwgJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFVU1NEAAAAAGtY3WxokwttAx3Fu/riPvoew/C7WMK8jZONR8Hfs75zAAAAHgAAAAAAAYagAAAAAAAAA+gAAAAAAAAB9AAAAAAAAAAZAAAAAAAAAAEAAAAAAAAABQECAwQFBgcICQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABVVNTRAAAAABrWN1saJMLbQMdxbv64j76HsPwu1jCvI2TjUfB37O+cwAAAB4AAAAAAAGKiAAAAAAAAARMAAAAAAAAAfYAAAAAAAAAGgAAAAAAAAACAAAAAwAAAAAAAAAFAQIDBAUGBwgJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFVU1NEAAAAAGtY3WxokwttAx3Fu/riPvoew/C7WMK8jZONR8Hfs75zAAAAHgAAAAAAAYagAAAAAAAAA+gAAAAAAAAB9AAAAAAAAAAZAAAAAAAAAAEAAAAAAAAABQECAwQFBgcICQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABVVNTRAAAAABrWN1saJMLbQMdxbv64j76HsPwu1jCvI2TjUfB37O+cwAAAB4AAAAAAAGKiAAAAAAAAARMAAAAAAAAAfYAAAAAAAAAGgAAAAAAAAAA",
+			TxFeeMeta:        "AAAAAA==",
 			TransactionHash:  "a87fef5eeb260269c380f2de456aad72b59bb315aaac777860456e09dac0bafb",
 			LedgerSequence:   30521816,
 			ApplicationOrder: 1,
@@ -99,6 +103,10 @@ func makeTransactionTestOutput() (output []TransactionOutput, err error) {
 			Successful:       false,
 		},
 		TransactionOutput{
+			TxEnvelope:           "AAAABQAAAABnzACGTDuJFoxqr+C8NHCe0CHFBXLi+YhhNCIILCIpcgAAAAAAABwgAAAAAgAAAACI4aa0pXFSj6qfJuIObLw/5zyugLRGYwxb7wFSr3B9eAAAAAACFPY2AAAAfQAAAAEAAAAAAAAAAAAAAABfBqt0AAAAAQAAABdITDVhQ2dvelFISVc3c1NjNVhkY2ZtUgAAAAABAAAAAQAAAAAcR0GXGO76pFs4y38vJVAanjnLg4emNun7zAx0pHcDGAAAAAIAAAAAAAAAAAAAAAAAAAAAAQIDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+			TxResult:             "AAAAAAAAASwAAAABqH/vXusmAmnDgPLeRWqtcrWbsxWqrHd4YEVuCdrAuvsAAAAAAAAAZAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+			TxMeta:               "AAAAAQAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAwAAAAAAAAAFAQIDBAUGBwgJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFVU1NEAAAAAGtY3WxokwttAx3Fu/riPvoew/C7WMK8jZONR8Hfs75zAAAAHgAAAAAAAYagAAAAAAAAA+gAAAAAAAAB9AAAAAAAAAAZAAAAAAAAAAEAAAAAAAAABQECAwQFBgcICQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABVVNTRAAAAABrWN1saJMLbQMdxbv64j76HsPwu1jCvI2TjUfB37O+cwAAAB4AAAAAAAGKiAAAAAAAAARMAAAAAAAAAfYAAAAAAAAAGgAAAAAAAAACAAAAAwAAAAAAAAAFAQIDBAUGBwgJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFVU1NEAAAAAGtY3WxokwttAx3Fu/riPvoew/C7WMK8jZONR8Hfs75zAAAAHgAAAAAAAYagAAAAAAAAA+gAAAAAAAAB9AAAAAAAAAAZAAAAAAAAAAEAAAAAAAAABQECAwQFBgcICQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABVVNTRAAAAABrWN1saJMLbQMdxbv64j76HsPwu1jCvI2TjUfB37O+cwAAAB4AAAAAAAGKiAAAAAAAAARMAAAAAAAAAfYAAAAAAAAAGgAAAAAAAAAA",
+			TxFeeMeta:            "AAAAAA==",
 			TransactionHash:      "a87fef5eeb260269c380f2de456aad72b59bb315aaac777860456e09dac0bafb",
 			LedgerSequence:       30521817,
 			ApplicationOrder:     1,
@@ -118,6 +126,10 @@ func makeTransactionTestOutput() (output []TransactionOutput, err error) {
 			NewMaxFee:            7200,
 		},
 		TransactionOutput{
+			TxEnvelope:                  "AAAAAgAAAAAcR0GXGO76pFs4y38vJVAanjnLg4emNun7zAx0pHcDGAAAAGQBpLyvsiV6gwAAAAIAAAABAAAAAAAAAAAAAAAAXwardAAAAAEAAAAFAAAACgAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAMCAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAABdITDVhQ2dvelFISVc3c1NjNVhkY2ZtUgAAAAABAAAAAQAAAABrWN1saJMLbQMdxbv64j76HsPwu1jCvI2TjUfB37O+cwAAAAIAAAAAAAAAAAAAAAAAAAAAAQIDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+			TxResult:                    "AAAAAAAAAGT/////AAAAAQAAAAAAAAAAAAAAAAAAAAA=",
+			TxMeta:                      "AAAAAQAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAwAAAAAAAAAFAQIDBAUGBwgJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFVU1NEAAAAAGtY3WxokwttAx3Fu/riPvoew/C7WMK8jZONR8Hfs75zAAAAHgAAAAAAAYagAAAAAAAAA+gAAAAAAAAB9AAAAAAAAAAZAAAAAAAAAAEAAAAAAAAABQECAwQFBgcICQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABVVNTRAAAAABrWN1saJMLbQMdxbv64j76HsPwu1jCvI2TjUfB37O+cwAAAB4AAAAAAAGKiAAAAAAAAARMAAAAAAAAAfYAAAAAAAAAGgAAAAAAAAACAAAAAwAAAAAAAAAFAQIDBAUGBwgJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFVU1NEAAAAAGtY3WxokwttAx3Fu/riPvoew/C7WMK8jZONR8Hfs75zAAAAHgAAAAAAAYagAAAAAAAAA+gAAAAAAAAB9AAAAAAAAAAZAAAAAAAAAAEAAAAAAAAABQECAwQFBgcICQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABVVNTRAAAAABrWN1saJMLbQMdxbv64j76HsPwu1jCvI2TjUfB37O+cwAAAB4AAAAAAAGKiAAAAAAAAARMAAAAAAAAAfYAAAAAAAAAGgAAAAAAAAAA",
+			TxFeeMeta:                   "AAAAAA==",
 			TransactionHash:             "a87fef5eeb260269c380f2de456aad72b59bb315aaac777860456e09dac0bafb",
 			LedgerSequence:              30521818,
 			ApplicationOrder:            1,
@@ -143,6 +155,21 @@ func makeTransactionTestOutput() (output []TransactionOutput, err error) {
 func makeTransactionTestInput() (transaction []ingest.LedgerTransaction, historyHeader []xdr.LedgerHeaderHistoryEntry, err error) {
 	hardCodedMemoText := "HL5aCgozQHIW7sSc5XdcfmR"
 	hardCodedTransactionHash := xdr.Hash([32]byte{0xa8, 0x7f, 0xef, 0x5e, 0xeb, 0x26, 0x2, 0x69, 0xc3, 0x80, 0xf2, 0xde, 0x45, 0x6a, 0xad, 0x72, 0xb5, 0x9b, 0xb3, 0x15, 0xaa, 0xac, 0x77, 0x78, 0x60, 0x45, 0x6e, 0x9, 0xda, 0xc0, 0xba, 0xfb})
+	genericResultResults := &[]xdr.OperationResult{
+		xdr.OperationResult{
+			Tr: &xdr.OperationResultTr{
+				Type: xdr.OperationTypeCreateAccount,
+				CreateAccountResult: &xdr.CreateAccountResult{
+					Code: 0,
+				},
+			},
+		},
+	}
+	hardCodedMeta := xdr.TransactionMeta{
+		V:  1,
+		V1: genericTxMeta,
+	}
+
 	source := xdr.MuxedAccount{
 		Type:    xdr.CryptoKeyTypeKeyTypeEd25519,
 		Ed25519: &xdr.Uint256{3, 2, 1},
@@ -157,11 +184,8 @@ func makeTransactionTestInput() (transaction []ingest.LedgerTransaction, history
 	}
 	transaction = []ingest.LedgerTransaction{
 		ingest.LedgerTransaction{
-			Index: 1,
-			UnsafeMeta: xdr.TransactionMeta{
-				V:  1,
-				V1: genericTxMeta,
-			},
+			Index:      1,
+			UnsafeMeta: hardCodedMeta,
 			Envelope: xdr.TransactionEnvelope{
 				Type: xdr.EnvelopeTypeEnvelopeTypeTx,
 				V1: &xdr.TransactionV1Envelope{
@@ -199,23 +223,15 @@ func makeTransactionTestInput() (transaction []ingest.LedgerTransaction, history
 				Result: xdr.TransactionResult{
 					FeeCharged: 300,
 					Result: xdr.TransactionResultResult{
-						Code: xdr.TransactionResultCodeTxFailed,
-						Results: &[]xdr.OperationResult{
-							xdr.OperationResult{
-								Tr: &xdr.OperationResultTr{
-									Type: xdr.OperationTypeCreateAccount,
-									CreateAccountResult: &xdr.CreateAccountResult{
-										Code: 0,
-									},
-								},
-							},
-						},
+						Code:    xdr.TransactionResultCodeTxFailed,
+						Results: genericResultResults,
 					},
 				},
 			},
 		},
 		ingest.LedgerTransaction{
-			Index: 1,
+			Index:      1,
+			UnsafeMeta: hardCodedMeta,
 			Envelope: xdr.TransactionEnvelope{
 				Type: xdr.EnvelopeTypeEnvelopeTypeTxFeeBump,
 				FeeBump: &xdr.FeeBumpTransactionEnvelope{
@@ -267,9 +283,13 @@ func makeTransactionTestInput() (transaction []ingest.LedgerTransaction, history
 							Result: xdr.InnerTransactionResult{
 								FeeCharged: 100,
 								Result: xdr.InnerTransactionResultResult{
-									Code: xdr.TransactionResultCodeTxFeeBumpInnerSuccess,
+									Code: xdr.TransactionResultCodeTxSuccess,
 									Results: &[]xdr.OperationResult{
-										xdr.OperationResult{},
+										xdr.OperationResult{
+											Tr: &xdr.OperationResultTr{
+												CreateAccountResult: &xdr.CreateAccountResult{},
+											},
+										},
 									},
 								},
 							},
@@ -282,7 +302,8 @@ func makeTransactionTestInput() (transaction []ingest.LedgerTransaction, history
 			},
 		},
 		ingest.LedgerTransaction{
-			Index: 1,
+			Index:      1,
+			UnsafeMeta: hardCodedMeta,
 			Envelope: xdr.TransactionEnvelope{
 				Type: xdr.EnvelopeTypeEnvelopeTypeTx,
 				V1: &xdr.TransactionV1Envelope{
@@ -327,10 +348,8 @@ func makeTransactionTestInput() (transaction []ingest.LedgerTransaction, history
 				Result: xdr.TransactionResult{
 					FeeCharged: 100,
 					Result: xdr.TransactionResultResult{
-						Code: xdr.TransactionResultCodeTxFailed,
-						Results: &[]xdr.OperationResult{
-							xdr.OperationResult{},
-						},
+						Code:    xdr.TransactionResultCodeTxFailed,
+						Results: genericResultResults,
 					},
 				},
 			},

--- a/internal/transform/transaction_test.go
+++ b/internal/transform/transaction_test.go
@@ -25,12 +25,12 @@ func TestTransformTransaction(t *testing.T) {
 	}
 	genericInput := inputStruct{genericLedgerTransaction, genericLedgerHeaderHistoryEntry}
 	negativeSeqInput := genericInput
-	negativeSeqEnvelope := genericBumpOperationEnvelope
+	negativeSeqEnvelope := genericBumpOperationEnvelopeForTransaction
 	negativeSeqEnvelope.Tx.SeqNum = xdr.SequenceNumber(-1)
 	negativeSeqInput.transaction.Envelope.V1 = &negativeSeqEnvelope
 
 	badTimeboundInput := genericInput
-	badTimeboundEnvelope := genericBumpOperationEnvelope
+	badTimeboundEnvelope := genericBumpOperationEnvelopeForTransaction
 	badTimeboundEnvelope.Tx.Cond.Type = xdr.PreconditionTypePrecondTime
 	badTimeboundEnvelope.Tx.Cond.TimeBounds = &xdr.TimeBounds{
 		MinTime: 1594586912,

--- a/internal/transform/transaction_test.go
+++ b/internal/transform/transaction_test.go
@@ -147,6 +147,10 @@ func makeTransactionTestInput() (transaction []ingest.LedgerTransaction, history
 		Type:    xdr.CryptoKeyTypeKeyTypeEd25519,
 		Ed25519: &xdr.Uint256{3, 2, 1},
 	}
+	destination := xdr.MuxedAccount{
+		Type:    xdr.CryptoKeyTypeKeyTypeEd25519,
+		Ed25519: &xdr.Uint256{1, 2, 3},
+	}
 	signerKey := xdr.SignerKey{
 		Type:    xdr.SignerKeyTypeSignerKeyTypeEd25519,
 		Ed25519: source.Ed25519,
@@ -154,6 +158,10 @@ func makeTransactionTestInput() (transaction []ingest.LedgerTransaction, history
 	transaction = []ingest.LedgerTransaction{
 		ingest.LedgerTransaction{
 			Index: 1,
+			UnsafeMeta: xdr.TransactionMeta{
+				V:  1,
+				V1: genericTxMeta,
+			},
 			Envelope: xdr.TransactionEnvelope{
 				Type: xdr.EnvelopeTypeEnvelopeTypeTx,
 				V1: &xdr.TransactionV1Envelope{
@@ -176,8 +184,10 @@ func makeTransactionTestInput() (transaction []ingest.LedgerTransaction, history
 							xdr.Operation{
 								SourceAccount: &testAccount2,
 								Body: xdr.OperationBody{
-									Type:                       xdr.OperationTypePathPaymentStrictReceive,
-									PathPaymentStrictReceiveOp: &xdr.PathPaymentStrictReceiveOp{},
+									Type: xdr.OperationTypePathPaymentStrictReceive,
+									PathPaymentStrictReceiveOp: &xdr.PathPaymentStrictReceiveOp{
+										Destination: destination,
+									},
 								},
 							},
 						},
@@ -191,7 +201,14 @@ func makeTransactionTestInput() (transaction []ingest.LedgerTransaction, history
 					Result: xdr.TransactionResultResult{
 						Code: xdr.TransactionResultCodeTxFailed,
 						Results: &[]xdr.OperationResult{
-							xdr.OperationResult{},
+							xdr.OperationResult{
+								Tr: &xdr.OperationResultTr{
+									Type: xdr.OperationTypeCreateAccount,
+									CreateAccountResult: &xdr.CreateAccountResult{
+										Code: 0,
+									},
+								},
+							},
 						},
 					},
 				},
@@ -226,8 +243,10 @@ func makeTransactionTestInput() (transaction []ingest.LedgerTransaction, history
 										xdr.Operation{
 											SourceAccount: &testAccount2,
 											Body: xdr.OperationBody{
-												Type:                       xdr.OperationTypePathPaymentStrictReceive,
-												PathPaymentStrictReceiveOp: &xdr.PathPaymentStrictReceiveOp{},
+												Type: xdr.OperationTypePathPaymentStrictReceive,
+												PathPaymentStrictReceiveOp: &xdr.PathPaymentStrictReceiveOp{
+													Destination: destination,
+												},
 											},
 										},
 									},
@@ -293,8 +312,10 @@ func makeTransactionTestInput() (transaction []ingest.LedgerTransaction, history
 							xdr.Operation{
 								SourceAccount: &testAccount4,
 								Body: xdr.OperationBody{
-									Type:                       xdr.OperationTypePathPaymentStrictReceive,
-									PathPaymentStrictReceiveOp: &xdr.PathPaymentStrictReceiveOp{},
+									Type: xdr.OperationTypePathPaymentStrictReceive,
+									PathPaymentStrictReceiveOp: &xdr.PathPaymentStrictReceiveOp{
+										Destination: destination,
+									},
 								},
 							},
 						},

--- a/internal/utils/main.go
+++ b/internal/utils/main.go
@@ -86,12 +86,20 @@ func CreateSampleResultMeta(successful bool, subOperationCount int) xdr.Transact
 		resultCode = xdr.TransactionResultCodeTxSuccess
 	}
 	operationResults := []xdr.OperationResult{}
+	operationResultTr := &xdr.OperationResultTr{
+		Type: xdr.OperationTypeCreateAccount,
+		CreateAccountResult: &xdr.CreateAccountResult{
+			Code: 0,
+		},
+	}
+
 	for i := 0; i < subOperationCount; i++ {
 		operationResults = append(operationResults, xdr.OperationResult{
 			Code: xdr.OperationResultCodeOpInner,
-			Tr:   &xdr.OperationResultTr{},
+			Tr:   operationResultTr,
 		})
 	}
+
 	return xdr.TransactionResultMeta{
 		Result: xdr.TransactionResultPair{
 			Result: xdr.TransactionResult{

--- a/internal/utils/main.go
+++ b/internal/utils/main.go
@@ -209,10 +209,10 @@ func AddGcsFlags(flags *pflag.FlagSet) {
 		"When run on GCP, credentials should be inferred by service account.")
 }
 
-// AddCoreFlags adds the captive core specifc flags: core-executable, core-config, batch-size, and output flags
+// AddCoreFlags adds the captive core specific flags: core-executable, core-config, batch-size, and output flags
 func AddCoreFlags(flags *pflag.FlagSet, defaultFolder string) {
 	flags.StringP("core-executable", "x", "", "Filepath to the stellar-core executable")
-	flags.StringP("core-config", "c", "", "Filepath to the a config file for stellar-core")
+	flags.StringP("core-config", "c", "", "Filepath to the config file for stellar-core")
 
 	flags.Uint32P("batch-size", "b", 64, "number of ledgers to export changes from in each batches")
 	flags.StringP("output", "o", defaultFolder, "Folder that will contain the output files")


### PR DESCRIPTION
**Overview**

This change adds *Transaction Envelope*, *Transaction Results*, *Transaction Meta* and *Transaction Fee Meta* to `history_operations`.
This also refactors the `GetTransactions` code to get data from *Captive Core*.
Another change includes refactoring the broken `Dockerfile` (#165).

**Changes**

- add new fields,`tx_envelope`, `tx_result`, `tx_meta` and `tx_fee_meta` to the `transactions` output
- update `transaction_test.go` to support the recently added fields
- refactor `input/transaction.go` to get data from *Captive Core*
- refactor `Dockerfile`

This PR needs to be merged before #164 so it won't have any conflicts.

Partially closes stellar/hubble [#298](https://github.com/stellar/hubble/issues/298)
Closes #165 