### PR TITLE
Fix WORKDIR path

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN go build -v -o /usr/local/bin ./...
 # stellar/stellar-core 19, pinned by sha digest
 FROM stellar/stellar-core@sha256:41107f7e3c8f5cbdf385bfda897bb56f862d1a9a757e948ba881ec566eb7dc72 AS run
 
-WORKDIR /etl/docker/
+WORKDIR /etl
 
 COPY --from=build /usr/local/bin/stellar-etl /usr/local/bin/stellar-etl
 COPY --from=build /usr/src/etl/docker docker


### PR DESCRIPTION
Remove the `/docker` append to keep the`WORKDIR` the same as the previous builds.