### PR TITLE
Rewrite historyarchive backend for export ledgers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN go build -v -o /usr/local/bin ./...
 # stage 2: runtime enviroment
 # stellar/stellar-core 19, pinned by sha digest
 # futurenet preview 10 core image
-FROM sreuland/stellar-core:19.11.1-1373.875f47e24.focal-soroban
+FROM tamirstellar/stellar-core:19.12.1-1390.b8c4fb63c.focal-soroban
 
 WORKDIR /etl
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
-	github.com/stellar/go v0.0.0-20230712190330-24d5ff6931f1
+	github.com/stellar/go v0.0.0-20230717164429-9f44cb5eb82e
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -394,8 +394,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.7.1 h1:pM5oEahlgWv/WnHXpgbKz7iLIxRf65tye2Ci+XFK5sk=
 github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
-github.com/stellar/go v0.0.0-20230712190330-24d5ff6931f1 h1:aEF4bwECcDcjmsiWKeicM/WHM4gxtQkkfztLtonTm4k=
-github.com/stellar/go v0.0.0-20230712190330-24d5ff6931f1/go.mod h1:j0lhmN0nnrC8bBZliIboeZeisxgUrSNxXGoxwQFyq94=
+github.com/stellar/go v0.0.0-20230717164429-9f44cb5eb82e h1:HPdcAiMyEMqNuGPhUQOgRD2pRQtjQ5dV5WKRUYkSHPs=
+github.com/stellar/go v0.0.0-20230717164429-9f44cb5eb82e/go.mod h1:j0lhmN0nnrC8bBZliIboeZeisxgUrSNxXGoxwQFyq94=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee h1:fbVs0xmXpBvVS4GBeiRmAE3Le70ofAqFMch1GTiq/e8=
 github.com/stellar/go-xdr v0.0.0-20211103144802-8017fc4bdfee/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/input/ledgers.go
+++ b/internal/input/ledgers.go
@@ -5,30 +5,30 @@ import (
 
 	"github.com/stellar/stellar-etl/internal/utils"
 
-	"github.com/stellar/go/xdr"
+	"github.com/stellar/go/historyarchive"
 )
 
 // GetLedgers returns a slice of ledger close metas for the ledgers in the provided range (inclusive on both ends)
-func GetLedgers(start, end uint32, limit int64, isTest bool, isFuturenet bool) ([]xdr.LedgerCloseMeta, error) {
+func GetLedgers(start, end uint32, limit int64, isTest bool, isFuturenet bool) ([]historyarchive.Ledger, error) {
 	env := utils.GetEnvironmentDetails(isTest, isFuturenet)
 	backend, err := utils.CreateBackend(start, end, env.ArchiveURLs)
 	if err != nil {
-		return []xdr.LedgerCloseMeta{}, err
+		return []historyarchive.Ledger{}, err
 	}
 
-	metaSlice := []xdr.LedgerCloseMeta{}
-	ctx := context.Background()
+	ledgerSlice := []historyarchive.Ledger{}
 	for seq := start; seq <= end; seq++ {
-		ledger, err := backend.GetLedger(ctx, seq)
+		ctx := context.Background()
+		ledger, err := backend.GetLedgerArchive(ctx, seq)
 		if err != nil {
-			return []xdr.LedgerCloseMeta{}, err
+			return []historyarchive.Ledger{}, err
 		}
 
-		metaSlice = append(metaSlice, ledger)
-		if int64(len(metaSlice)) >= limit && limit >= 0 {
+		ledgerSlice = append(ledgerSlice, ledger)
+		if int64(len(ledgerSlice)) >= limit && limit >= 0 {
 			break
 		}
 	}
 
-	return metaSlice, nil
+	return ledgerSlice, nil
 }

--- a/internal/transform/ledger.go
+++ b/internal/transform/ledger.go
@@ -7,57 +7,57 @@ import (
 	"github.com/stellar/stellar-etl/internal/toid"
 	"github.com/stellar/stellar-etl/internal/utils"
 
+	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/xdr"
 )
 
-//TransformLedger converts a ledger from the history archive ingestion system into a form suitable for BigQuery
-func TransformLedger(inputLedgerMeta xdr.LedgerCloseMeta) (LedgerOutput, error) {
+// TransformLedger converts a ledger from the history archive ingestion system into a form suitable for BigQuery
+func TransformLedger(inputLedger historyarchive.Ledger) (LedgerOutput, error) {
 
-	ledgerHeaderHistory := inputLedgerMeta.LedgerHeaderHistoryEntry()
-	ledgerHeader := ledgerHeaderHistory.Header
+	ledgerHeader := inputLedger.Header.Header
 
-	outputSequence := uint32(ledgerHeader.LedgerSeq)
+	outputSequence := uint32(inputLedger.Header.Header.LedgerSeq)
 
 	outputLedgerID := toid.New(int32(outputSequence), 0, 0).ToInt64()
 
-	outputLedgerHash := utils.HashToHexString(ledgerHeaderHistory.Hash)
-	outputPreviousHash := utils.HashToHexString(ledgerHeader.PreviousLedgerHash)
+	outputLedgerHash := utils.HashToHexString(inputLedger.Header.Hash)
+	outputPreviousHash := utils.HashToHexString(inputLedger.Header.Header.PreviousLedgerHash)
 
 	outputLedgerHeader, err := xdr.MarshalBase64(ledgerHeader)
 	if err != nil {
 		return LedgerOutput{}, fmt.Errorf("for ledger %d (ledger id=%d): %v", outputSequence, outputLedgerID, err)
 	}
 
-	outputTransactionCount, outputOperationCount, outputSuccessfulCount, outputFailedCount, outputTxSetOperationCount, err := extractCounts(inputLedgerMeta)
+	outputTransactionCount, outputOperationCount, outputSuccessfulCount, outputFailedCount, outputTxSetOperationCount, err := extractCounts(inputLedger)
 	if err != nil {
 		return LedgerOutput{}, fmt.Errorf("for ledger %d (ledger id=%d): %v", outputSequence, outputLedgerID, err)
 	}
 
-	outputCloseTime, err := utils.TimePointToUTCTimeStamp(ledgerHeader.ScpValue.CloseTime)
+	outputCloseTime, err := utils.TimePointToUTCTimeStamp(inputLedger.Header.Header.ScpValue.CloseTime)
 	if err != nil {
 		return LedgerOutput{}, fmt.Errorf("for ledger %d (ledger id=%d): %v", outputSequence, outputLedgerID, err)
 	}
 
-	outputTotalCoins := int64(ledgerHeader.TotalCoins)
+	outputTotalCoins := int64(inputLedger.Header.Header.TotalCoins)
 	if outputTotalCoins < 0 {
-		return LedgerOutput{}, fmt.Errorf("The total number of coins (%d) is negative for ledger %d (ledger id=%d)", outputTotalCoins, outputSequence, outputLedgerID)
+		return LedgerOutput{}, fmt.Errorf("the total number of coins (%d) is negative for ledger %d (ledger id=%d)", outputTotalCoins, outputSequence, outputLedgerID)
 	}
 
-	outputFeePool := int64(ledgerHeader.FeePool)
+	outputFeePool := int64(inputLedger.Header.Header.FeePool)
 	if outputFeePool < 0 {
-		return LedgerOutput{}, fmt.Errorf("The fee pool (%d) is negative for ledger %d (ledger id=%d)", outputFeePool, outputSequence, outputLedgerID)
+		return LedgerOutput{}, fmt.Errorf("the fee pool (%d) is negative for ledger %d (ledger id=%d)", outputFeePool, outputSequence, outputLedgerID)
 	}
 
-	outputBaseFee := uint32(ledgerHeader.BaseFee)
+	outputBaseFee := uint32(inputLedger.Header.Header.BaseFee)
 
-	outputBaseReserve := uint32(ledgerHeader.BaseReserve)
+	outputBaseReserve := uint32(inputLedger.Header.Header.BaseReserve)
 
-	outputMaxTxSetSize := uint32(ledgerHeader.MaxTxSetSize)
+	outputMaxTxSetSize := uint32(inputLedger.Header.Header.MaxTxSetSize)
 	if int64(outputMaxTxSetSize) < int64(outputTransactionCount) {
-		return LedgerOutput{}, fmt.Errorf("The transaction count is greater than the maximum transaction set size (%d > %d) for ledger %d (ledger id=%d)", outputTransactionCount, outputMaxTxSetSize, outputSequence, outputLedgerID)
+		return LedgerOutput{}, fmt.Errorf("the transaction count is greater than the maximum transaction set size (%d > %d) for ledger %d (ledger id=%d)", outputTransactionCount, outputMaxTxSetSize, outputSequence, outputLedgerID)
 	}
 
-	outputProtocolVersion := uint32(ledgerHeader.LedgerVersion)
+	outputProtocolVersion := uint32(inputLedger.Header.Header.LedgerVersion)
 
 	transformedLedger := LedgerOutput{
 		Sequence:                   outputSequence,
@@ -81,17 +81,18 @@ func TransformLedger(inputLedgerMeta xdr.LedgerCloseMeta) (LedgerOutput, error) 
 	return transformedLedger, nil
 }
 
-func extractCounts(lcm xdr.LedgerCloseMeta) (transactionCount int32, operationCount int32, successTxCount int32, failedTxCount int32, txSetOperationCount string, err error) {
-	results := getTransactionProcessing(lcm)
-	txCount := lcm.CountTransactions()
+func extractCounts(ledger historyarchive.Ledger) (transactionCount int32, operationCount int32, successTxCount int32, failedTxCount int32, txSetOperationCount string, err error) {
+	transactions := getTransactionSet(ledger)
+	results := ledger.TransactionResult.TxResultSet.Results
+	txCount := len(transactions)
 	if txCount != len(results) {
-		err = fmt.Errorf("The number of transactions and results are different (%d != %d)", txCount, len(results))
+		err = fmt.Errorf("the number of transactions and results are different (%d != %d)", txCount, len(results))
 		return
 	}
 
 	txSetOperationCounter := int32(0)
 	for i := 0; i < txCount; i++ {
-		operations, _ := results[i].Result.Result.OperationResults()
+		operations := transactions[i].Operations()
 		numberOfOps := int32(len(operations))
 		txSetOperationCounter += numberOfOps
 
@@ -99,7 +100,7 @@ func extractCounts(lcm xdr.LedgerCloseMeta) (transactionCount int32, operationCo
 		if results[i].Result.Successful() {
 			operationResults, ok := results[i].Result.OperationResults()
 			if !ok {
-				err = fmt.Errorf("Could not access operation results for result %d", i)
+				err = fmt.Errorf("could not access operation results for result %d", i)
 				return
 			}
 
@@ -113,18 +114,39 @@ func extractCounts(lcm xdr.LedgerCloseMeta) (transactionCount int32, operationCo
 	transactionCount = int32(txCount) - failedTxCount
 	txSetOperationCount = strconv.FormatInt(int64(txSetOperationCounter), 10)
 	return
+
 }
 
-func getTransactionProcessing(ledgerCloseMeta xdr.LedgerCloseMeta) (transactionProcessing []xdr.TransactionResultMeta) {
-	switch ledgerCloseMeta.V {
+func getTransactionSet(transactionEntry historyarchive.Ledger) (transactionProcessing []xdr.TransactionEnvelope) {
+	switch transactionEntry.Transaction.Ext.V {
 	case 0:
-		return ledgerCloseMeta.V0.TxProcessing
+		return transactionEntry.Transaction.TxSet.Txs
 	case 1:
-		return ledgerCloseMeta.V1.TxProcessing
-	case 2:
-		return ledgerCloseMeta.V2.TxProcessing
+		return getTransactionPhase(transactionEntry.Transaction.Ext.GeneralizedTxSet.V1TxSet.Phases)
 	default:
-		panic(fmt.Sprintf("Unsupported LedgerCloseMeta.V: %d", ledgerCloseMeta.V))
+		panic(fmt.Sprintf("Unsupported TransactionHistoryEntry.Ext: %d", transactionEntry.Transaction.Ext.V))
 	}
 }
 
+func getTransactionPhase(transactionPhase []xdr.TransactionPhase) (transactionEnvelope []xdr.TransactionEnvelope) {
+	transactionSlice := []xdr.TransactionEnvelope{}
+	for _, phase := range transactionPhase {
+		switch phase.V {
+		case 0:
+			for _, component := range *phase.V0Components {
+				switch component.Type {
+				case 0:
+					transactionSlice = append(transactionSlice, component.TxsMaybeDiscountedFee.Txs...)
+
+				default:
+					panic(fmt.Sprintf("Unsupported TxSetComponentType: %d", component.Type))
+				}
+
+			}
+		default:
+			panic(fmt.Sprintf("Unsupported TransactionPhase.V: %d", phase.V))
+		}
+	}
+	return transactionSlice
+
+}

--- a/internal/transform/ledger_test.go
+++ b/internal/transform/ledger_test.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/stellar/stellar-etl/internal/utils"
 
+	"github.com/stellar/go/historyarchive"
 	"github.com/stellar/go/xdr"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestTransformLedger(t *testing.T) {
 	type transformTest struct {
-		input      xdr.LedgerCloseMeta
+		input      historyarchive.Ledger
 		wantOutput LedgerOutput
 		wantErr    error
 	}
@@ -25,18 +26,26 @@ func TestTransformLedger(t *testing.T) {
 
 	tests := []transformTest{
 		{
-			wrapLedgerHeader(xdr.LedgerHeader{
-				TotalCoins: -1,
-			}),
+			historyarchive.Ledger{
+				Header: xdr.LedgerHeaderHistoryEntry{
+					Header: xdr.LedgerHeader{
+						TotalCoins: -1,
+					},
+				},
+			},
 			LedgerOutput{},
-			fmt.Errorf("The total number of coins (-1) is negative for ledger 0 (ledger id=0)"),
+			fmt.Errorf("the total number of coins (-1) is negative for ledger 0 (ledger id=0)"),
 		},
 		{
-			wrapLedgerHeader(xdr.LedgerHeader{
-				FeePool: -1,
-			}),
+			historyarchive.Ledger{
+				Header: xdr.LedgerHeaderHistoryEntry{
+					Header: xdr.LedgerHeader{
+						FeePool: -1,
+					},
+				},
+			},
 			LedgerOutput{},
-			fmt.Errorf("The fee pool (-1) is negative for ledger 0 (ledger id=0)"),
+			fmt.Errorf("the fee pool (-1) is negative for ledger 0 (ledger id=0)"),
 		},
 		{
 			hardCodedLedger,
@@ -78,24 +87,24 @@ func makeLedgerTestOutput() (output LedgerOutput, err error) {
 		OperationCount:             10,
 		SuccessfulTransactionCount: 1,
 		FailedTransactionCount:     1,
-		TxSetOperationCount:        "13",
+		TxSetOperationCount:        "2",
 	}
 	return
 }
 
-func makeLedgerTestInput() (lcm xdr.LedgerCloseMeta, err error) {
+func makeLedgerTestInput() (lcm historyarchive.Ledger, err error) {
 	hardCodedTxSet := xdr.TransactionSet{
 		Txs: []xdr.TransactionEnvelope{
 			utils.CreateSampleTx(0),
 			utils.CreateSampleTx(1),
 		},
 	}
-	hardCodedTxProcessing := []xdr.TransactionResultMeta{
-		utils.CreateSampleResultMeta(false, 3),
-		utils.CreateSampleResultMeta(true, 10),
+	hardCodedTxProcessing := []xdr.TransactionResultPair{
+		utils.CreateSampleResultPair(false, 3),
+		utils.CreateSampleResultPair(true, 10),
 	}
-	lcm, err = xdr.NewLedgerCloseMeta(0, xdr.LedgerCloseMetaV0{
-		LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+	lcm = historyarchive.Ledger{
+		Header: xdr.LedgerHeaderHistoryEntry{
 			Header: xdr.LedgerHeader{
 				LedgerSeq:          30578981,
 				TotalCoins:         1054439020873472865,
@@ -109,25 +118,14 @@ func makeLedgerTestInput() (lcm xdr.LedgerCloseMeta, err error) {
 			},
 			Hash: xdr.Hash{0x26, 0x93, 0x2d, 0xc4, 0xd8, 0x4b, 0x5f, 0xab, 0xe9, 0xae, 0x74, 0x4c, 0xb4, 0x3c, 0xe4, 0xc6, 0xda, 0xcc, 0xf9, 0x8c, 0x86, 0xa9, 0x91, 0xb2, 0xa1, 0x49, 0x45, 0xb1, 0xad, 0xac, 0x4d, 0x59},
 		},
-		TxSet:        hardCodedTxSet,
-		TxProcessing: hardCodedTxProcessing,
-	})
-	return
-}
-func wrapLedgerHeaderWithTransactions(header xdr.LedgerHeader, numTransactions int) xdr.LedgerCloseMeta {
-	transactionEnvelopes := []xdr.TransactionEnvelope{}
-	for txNum := 0; txNum < numTransactions; txNum++ {
-		transactionEnvelopes = append(transactionEnvelopes, utils.CreateSampleTx(int64(txNum)))
-	}
-	lcm, _ := xdr.NewLedgerCloseMeta(0, xdr.LedgerCloseMetaV0{
-		LedgerHeader: xdr.LedgerHeaderHistoryEntry{
-			Header: header,
+		Transaction: xdr.TransactionHistoryEntry{
+			LedgerSeq: 30578981,
+			TxSet:     hardCodedTxSet,
 		},
-		TxSet: xdr.TransactionSet{Txs: transactionEnvelopes},
-	})
-	return lcm
-}
-
-func wrapLedgerHeader(header xdr.LedgerHeader) xdr.LedgerCloseMeta {
-	return wrapLedgerHeaderWithTransactions(header, 0)
+		TransactionResult: xdr.TransactionHistoryResultEntry{
+			LedgerSeq:   30578981,
+			TxResultSet: xdr.TransactionResultSet{hardCodedTxProcessing},
+		},
+	}
+	return lcm, nil
 }

--- a/internal/utils/main.go
+++ b/internal/utils/main.go
@@ -37,7 +37,7 @@ func HashToHexString(inputHash xdr.Hash) string {
 func TimePointToUTCTimeStamp(providedTime xdr.TimePoint) (time.Time, error) {
 	intTime := int64(providedTime)
 	if intTime < 0 {
-		return time.Now(), errors.New("The timepoint is negative")
+		return time.Now(), errors.New("the timepoint is negative")
 	}
 	return time.Unix(intTime, 0).UTC(), nil
 }
@@ -107,6 +107,37 @@ func CreateSampleResultMeta(successful bool, subOperationCount int) xdr.Transact
 					Code:    resultCode,
 					Results: &operationResults,
 				},
+			},
+		},
+	}
+}
+
+func CreateSampleResultPair(successful bool, subOperationCount int) xdr.TransactionResultPair {
+	resultCode := xdr.TransactionResultCodeTxFailed
+	if successful {
+		resultCode = xdr.TransactionResultCodeTxSuccess
+	}
+	operationResults := []xdr.OperationResult{}
+	operationResultTr := &xdr.OperationResultTr{
+		Type: xdr.OperationTypeCreateAccount,
+		CreateAccountResult: &xdr.CreateAccountResult{
+			Code: 0,
+		},
+	}
+
+	for i := 0; i < subOperationCount; i++ {
+		operationResults = append(operationResults, xdr.OperationResult{
+			Code: xdr.OperationResultCodeOpInner,
+			Tr:   operationResultTr,
+		})
+	}
+
+	return xdr.TransactionResultPair{
+		TransactionHash: xdr.Hash{},
+		Result: xdr.TransactionResult{
+			Result: xdr.TransactionResultResult{
+				Code:    resultCode,
+				Results: &operationResults,
 			},
 		},
 	}
@@ -383,6 +414,26 @@ func (h historyArchiveBackend) GetLatestLedgerSequence(ctx context.Context) (seq
 	return root.CurrentLedger, nil
 }
 
+func (h historyArchiveBackend) GetLedgers(ctx context.Context) (map[uint32]*historyarchive.Ledger, error) {
+
+	return h.ledgers, nil
+}
+
+func (h historyArchiveBackend) GetLedgerArchive(ctx context.Context, sequence uint32) (historyarchive.Ledger, error) {
+	ledger, ok := h.ledgers[sequence]
+	if !ok {
+		return historyarchive.Ledger{}, fmt.Errorf("ledger %d is missing from map", sequence)
+	}
+
+	historyLedger := historyarchive.Ledger{
+		Header:            ledger.Header,
+		Transaction:       ledger.Transaction,
+		TransactionResult: ledger.TransactionResult,
+	}
+
+	return historyLedger, nil
+}
+
 func (h historyArchiveBackend) GetLedger(ctx context.Context, sequence uint32) (xdr.LedgerCloseMeta, error) {
 	ledger, ok := h.ledgers[sequence]
 	if !ok {
@@ -419,45 +470,45 @@ func (h historyArchiveBackend) Close() error {
 // ValidateLedgerRange validates the given ledger range
 func ValidateLedgerRange(start, end, latestNum uint32) error {
 	if start == 0 {
-		return fmt.Errorf("Start sequence number equal to 0. There is no ledger 0 (genesis ledger is ledger 1)")
+		return fmt.Errorf("start sequence number equal to 0. There is no ledger 0 (genesis ledger is ledger 1)")
 	}
 
 	if end == 0 {
-		return fmt.Errorf("End sequence number equal to 0. There is no ledger 0 (genesis ledger is ledger 1)")
+		return fmt.Errorf("end sequence number equal to 0. There is no ledger 0 (genesis ledger is ledger 1)")
 	}
 
 	if end < start {
-		return fmt.Errorf("End sequence number is less than start (%d < %d)", end, start)
+		return fmt.Errorf("end sequence number is less than start (%d < %d)", end, start)
 	}
 
 	if latestNum < start {
-		return fmt.Errorf("Latest sequence number is less than start sequence number (%d < %d)", latestNum, start)
+		return fmt.Errorf("latest sequence number is less than start sequence number (%d < %d)", latestNum, start)
 	}
 
 	if latestNum < end {
-		return fmt.Errorf("Latest sequence number is less than end sequence number (%d < %d)", latestNum, end)
+		return fmt.Errorf("latest sequence number is less than end sequence number (%d < %d)", latestNum, end)
 	}
 
 	return nil
 }
 
-func CreateBackend(start, end uint32, archiveURLs []string) (ledgerbackend.LedgerBackend, error) {
+func CreateBackend(start, end uint32, archiveURLs []string) (historyArchiveBackend, error) {
 	client, err := CreateHistoryArchiveClient(archiveURLs)
 	if err != nil {
-		return nil, err
+		return historyArchiveBackend{}, err
 	}
 
 	root, err := client.GetRootHAS()
 	if err != nil {
-		return nil, err
+		return historyArchiveBackend{}, err
 	}
 	if err = ValidateLedgerRange(start, end, root.CurrentLedger); err != nil {
-		return nil, err
+		return historyArchiveBackend{}, err
 	}
 
 	ledgers, err := client.GetLedgers(start, end)
 	if err != nil {
-		return nil, err
+		return historyArchiveBackend{}, err
 	}
 	return historyArchiveBackend{client: client, ledgers: ledgers}, nil
 }
@@ -516,7 +567,7 @@ func GetCheckpointNum(seq, maxSeq uint32) (uint32, error) {
 
 	checkpoint := seq + 64 - remainder
 	if checkpoint > maxSeq {
-		return 0, fmt.Errorf("The checkpoint ledger %d is greater than the max ledger number %d", checkpoint, maxSeq)
+		return 0, fmt.Errorf("the checkpoint ledger %d is greater than the max ledger number %d", checkpoint, maxSeq)
 	}
 
 	return checkpoint, nil
@@ -571,7 +622,7 @@ func GetEnvironmentDetails(isTest bool, isFuture bool) (details EnvironmentDetai
 		details.BinaryPath = "/usr/bin/stellar-core"
 		details.CoreConfig = "docker/stellar-core_futurenet.cfg"
 		return details
-    } else {
+	} else {
 		// default: mainnet
 		details.NetworkPassphrase = network.PublicNetworkPassphrase
 		details.ArchiveURLs = mainArchiveURLs


### PR DESCRIPTION
The way that the `export_ledgers` job ingests ledgers is incorrect and introduces the job to operational risk.

Because ledger data can be parsed without a captive core, the original `ledgerbackend` read ledgers from history archive, but spoofed the existence of `LedgerCloseMeta` so that the code could reuse the same backend used in the other ETL jobs. This is risky because the `LedgerCloseMeta` is hardcoded and assumes that the data read followed a `V0` format for `LedgerCloseMeta`

This PR refactors the code to use a custom create backend, `historyarchive` and ingests the `Ledger` directly from the archive instead of passing through a spoofed `ledgerbackend`