### PR TITLE
Refactor assets backend

### DIFF
--- a/cmd/export_assets.go
+++ b/cmd/export_assets.go
@@ -33,9 +33,9 @@ var assetsCmd = &cobra.Command{
 		numFailures := 0
 		totalNumBytes := 0
 		for _, transformInput := range paymentOps {
-			transformed, err := transform.TransformAsset(transformInput.Operation, transformInput.OperationIndex, transformInput.Transaction, transformInput.LedgerSeqNum)
+			transformed, err := transform.TransformAsset(transformInput.Operation, transformInput.OperationIndex, transformInput.TransactionIndex, transformInput.LedgerSeqNum)
 			if err != nil {
-				txIndex := transformInput.Transaction.Index
+				txIndex := transformInput.TransactionIndex
 				cmdLogger.LogError(fmt.Errorf("could not extract asset from operation %d in transaction %d in ledger %d: ", transformInput.OperationIndex, txIndex, transformInput.LedgerSeqNum))
 				numFailures += 1
 				continue
@@ -57,7 +57,7 @@ var assetsCmd = &cobra.Command{
 		}
 
 		outFile.Close()
-		cmdLogger.Infof("%d bytes written to %s: %d ", totalNumBytes, outFile.Name())
+		cmdLogger.Infof("%d bytes written to %s", totalNumBytes, outFile.Name())
 
 		printTransformStats(len(paymentOps), numFailures)
 

--- a/internal/input/assets.go
+++ b/internal/input/assets.go
@@ -49,6 +49,9 @@ func GetPaymentOperations(start, end uint32, limit int64, isTest bool, isFuture 
 			}
 
 		}
+		if int64(len(assetSlice)) >= limit && limit >= 0 {
+			break
+		}
 	}
 
 	return assetSlice, nil

--- a/internal/input/assets.go
+++ b/internal/input/assets.go
@@ -2,57 +2,54 @@ package input
 
 import (
 	"context"
-	"io"
 
+	"github.com/stellar/stellar-etl/internal/transform"
 	"github.com/stellar/stellar-etl/internal/utils"
 
-	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/xdr"
 )
 
+type AssetTransformInput struct {
+	Operation        xdr.Operation
+	OperationIndex   int32
+	TransactionIndex int32
+	LedgerSeqNum     int32
+}
+
 // GetPaymentOperations returns a slice of payment operations that can include new assets from the ledgers in the provided range (inclusive on both ends)
-func GetPaymentOperations(start, end uint32, limit int64, isTest bool, isFuture bool) ([]OperationTransformInput, error) {
+func GetPaymentOperations(start, end uint32, limit int64, isTest bool, isFuture bool) ([]AssetTransformInput, error) {
 	env := utils.GetEnvironmentDetails(isTest, isFuture)
 	backend, err := utils.CreateBackend(start, end, env.ArchiveURLs)
 	if err != nil {
-		return []OperationTransformInput{}, err
+		return []AssetTransformInput{}, err
 	}
 
-	opSlice := []OperationTransformInput{}
+	assetSlice := []AssetTransformInput{}
 	ctx := context.Background()
 	for seq := start; seq <= end; seq++ {
-		txReader, err := ingest.NewLedgerTransactionReader(ctx, backend, env.NetworkPassphrase, seq)
+		// Get ledger from sequence number
+		ledger, err := backend.GetLedgerArchive(ctx, seq)
 		if err != nil {
-			return []OperationTransformInput{}, err
+			return []AssetTransformInput{}, err
 		}
 
-		for int64(len(opSlice)) < limit || limit < 0 {
-			tx, err := txReader.Read()
-			if err == io.EOF {
-				break
-			}
+		transactionSet := transform.GetTransactionSet(ledger)
 
-			for index, op := range tx.Envelope.Operations() {
+		for txIndex, transaction := range transactionSet {
+			for opIndex, op := range transaction.Operations() {
 				if op.Body.Type == xdr.OperationTypePayment {
-					opSlice = append(opSlice, OperationTransformInput{
-						Operation:      op,
-						OperationIndex: int32(index),
-						Transaction:    tx,
-						LedgerSeqNum:   int32(seq),
+					assetSlice = append(assetSlice, AssetTransformInput{
+						Operation:        op,
+						OperationIndex:   int32(opIndex),
+						TransactionIndex: int32(txIndex),
+						LedgerSeqNum:     int32(seq),
 					})
 				}
 
-				if int64(len(opSlice)) >= limit && limit >= 0 {
-					break
-				}
 			}
-		}
 
-		txReader.Close()
-		if int64(len(opSlice)) >= limit && limit >= 0 {
-			break
 		}
 	}
 
-	return opSlice, nil
+	return assetSlice, nil
 }

--- a/internal/transform/asset.go
+++ b/internal/transform/asset.go
@@ -7,22 +7,21 @@ import (
 	"github.com/dgryski/go-farm"
 	"github.com/stellar/stellar-etl/internal/toid"
 
-	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/xdr"
 )
 
 // TransformAsset converts an asset from a payment operation into a form suitable for BigQuery
-func TransformAsset(operation xdr.Operation, operationIndex int32, transaction ingest.LedgerTransaction, ledgerSeq int32) (AssetOutput, error) {
-	operationID := toid.New(ledgerSeq, int32(transaction.Index), operationIndex).ToInt64()
+func TransformAsset(operation xdr.Operation, operationIndex int32, transactionIndex int32, ledgerSeq int32) (AssetOutput, error) {
+	operationID := toid.New(ledgerSeq, int32(transactionIndex), operationIndex).ToInt64()
 
 	opType := operation.Body.Type
 	if opType != xdr.OperationTypePayment {
-		return AssetOutput{}, fmt.Errorf("Operation of type %d cannot issue an asset (id %d)", opType, operationID)
+		return AssetOutput{}, fmt.Errorf("operation of type %d cannot issue an asset (id %d)", opType, operationID)
 	}
 
 	op, ok := operation.Body.GetPaymentOp()
 	if !ok {
-		return AssetOutput{}, fmt.Errorf("Could not access Payment info for this operation (id %d)", operationID)
+		return AssetOutput{}, fmt.Errorf("could not access Payment info for this operation (id %d)", operationID)
 	}
 
 	outputAsset, err := transformSingleAsset(op.Asset)
@@ -37,12 +36,12 @@ func transformSingleAsset(asset xdr.Asset) (AssetOutput, error) {
 	var outputAssetType, outputAssetCode, outputAssetIssuer string
 	err := asset.Extract(&outputAssetType, &outputAssetCode, &outputAssetIssuer)
 	if err != nil {
-		return AssetOutput{}, fmt.Errorf("Could not extract asset from this operation")
+		return AssetOutput{}, fmt.Errorf("could not extract asset from this operation")
 	}
 
 	outputAssetID, err := hashAsset(outputAssetCode, outputAssetIssuer)
 	if err != nil {
-		return AssetOutput{}, fmt.Errorf("Unable to hash asset for payment operation")
+		return AssetOutput{}, fmt.Errorf("unable to hash asset for payment operation")
 	}
 
 	farmAssetID := FarmHashAsset(outputAssetCode, outputAssetIssuer, outputAssetType)

--- a/internal/transform/asset_test.go
+++ b/internal/transform/asset_test.go
@@ -6,107 +6,122 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/xdr"
 )
 
 func TestTransformAsset(t *testing.T) {
-	type operationInput struct {
-		operation   xdr.Operation
-		index       int32
-		transaction ingest.LedgerTransaction
+	// type operationInput struct {
+	// 	operation   xdr.Operation
+	// 	index       int32
+	// 	transaction ingest.LedgerTransaction
+	// }
+	type assetInput struct {
+		operation xdr.Operation
+		index     int32
+		txnIndex  int32
+		// transaction xdr.TransactionEnvelope
 	}
+	// type transformTest struct {
+	// 	input      operationInput
+	// 	wantOutput AssetOutput
+	// 	wantErr    error
+	// }
 	type transformTest struct {
-		input      operationInput
+		input      assetInput
 		wantOutput AssetOutput
 		wantErr    error
 	}
 
-	nonPaymentInput := operationInput{
-		operation:   genericBumpOperation,
-		transaction: genericLedgerTransaction,
-		index:       0,
+	// nonPaymentInput := operationInput{
+	// 	operation:   genericBumpOperation,
+	// 	transaction: genericLedgerTransaction,
+	// 	index:       0,
+	// }
+	nonPaymentInput := assetInput{
+		operation: genericBumpOperation,
+		txnIndex:  0,
+		index:     0,
 	}
 
 	tests := []transformTest{
 		{
 			input:      nonPaymentInput,
 			wantOutput: AssetOutput{},
-			wantErr:    fmt.Errorf("Operation of type 11 cannot issue an asset (id 4096)"),
+			wantErr:    fmt.Errorf("operation of type 11 cannot issue an asset (id 0)"),
 		},
 	}
 
-	hardCodedInputTransaction, err := makeAssetTestInput()
-	assert.NoError(t, err)
-	hardCodedOutputArray := makeAssetTestOutput()
+	// hardCodedInputTransaction, err := makeAssetTestInput()
+	// assert.NoError(t, err)
+	// hardCodedOutputArray := makeAssetTestOutput()
 
-	for i, op := range hardCodedInputTransaction.Envelope.Operations() {
-		tests = append(tests, transformTest{
-			input:      operationInput{op, int32(i), hardCodedInputTransaction},
-			wantOutput: hardCodedOutputArray[i],
-			wantErr:    nil,
-		})
-	}
+	// for i, op := range hardCodedInputTransaction.Envelope.Operations() {
+	// 	tests = append(tests, transformTest{
+	// 		input:      operationInput{op, int32(i), hardCodedInputTransaction},
+	// 		wantOutput: hardCodedOutputArray[i],
+	// 		wantErr:    nil,
+	// 	})
+	// }
 
 	for _, test := range tests {
-		actualOutput, actualError := TransformAsset(test.input.operation, test.input.index, test.input.transaction, 0)
+		actualOutput, actualError := TransformAsset(test.input.operation, test.input.index, test.input.txnIndex, 0)
 		assert.Equal(t, test.wantErr, actualError)
 		assert.Equal(t, test.wantOutput, actualOutput)
 	}
 }
 
-func makeAssetTestInput() (inputTransaction ingest.LedgerTransaction, err error) {
-	inputTransaction = genericLedgerTransaction
-	inputEnvelope := genericBumpOperationEnvelope
+// func makeAssetTestInput() (inputTransaction ingest.LedgerTransaction, err error) {
+// 	inputTransaction = genericLedgerTransaction
+// 	inputEnvelope := genericBumpOperationEnvelope
 
-	inputEnvelope.Tx.SourceAccount = testAccount1
+// 	inputEnvelope.Tx.SourceAccount = testAccount1
 
-	inputOperations := []xdr.Operation{
-		xdr.Operation{
-			SourceAccount: nil,
-			Body: xdr.OperationBody{
-				Type: xdr.OperationTypePayment,
-				PaymentOp: &xdr.PaymentOp{
-					Destination: testAccount2,
-					Asset:       usdtAsset,
-					Amount:      350000000,
-				},
-			},
-		},
-		xdr.Operation{
-			SourceAccount: nil,
-			Body: xdr.OperationBody{
-				Type: xdr.OperationTypePayment,
-				PaymentOp: &xdr.PaymentOp{
-					Destination: testAccount3,
-					Asset:       nativeAsset,
-					Amount:      350000000,
-				},
-			},
-		},
-	}
+// 	inputOperations := []xdr.Operation{
+// 		xdr.Operation{
+// 			SourceAccount: nil,
+// 			Body: xdr.OperationBody{
+// 				Type: xdr.OperationTypePayment,
+// 				PaymentOp: &xdr.PaymentOp{
+// 					Destination: testAccount2,
+// 					Asset:       usdtAsset,
+// 					Amount:      350000000,
+// 				},
+// 			},
+// 		},
+// 		xdr.Operation{
+// 			SourceAccount: nil,
+// 			Body: xdr.OperationBody{
+// 				Type: xdr.OperationTypePayment,
+// 				PaymentOp: &xdr.PaymentOp{
+// 					Destination: testAccount3,
+// 					Asset:       nativeAsset,
+// 					Amount:      350000000,
+// 				},
+// 			},
+// 		},
+// 	}
 
-	inputEnvelope.Tx.Operations = inputOperations
-	inputTransaction.Envelope.V1 = &inputEnvelope
-	return
-}
+// 	inputEnvelope.Tx.Operations = inputOperations
+// 	inputTransaction.Envelope.V1 = &inputEnvelope
+// 	return
+// }
 
-func makeAssetTestOutput() (transformedAssets []AssetOutput) {
-	transformedAssets = []AssetOutput{
-		AssetOutput{
-			AssetCode:   "USDT",
-			AssetIssuer: "GBVVRXLMNCJQW3IDDXC3X6XCH35B5Q7QXNMMFPENSOGUPQO7WO7HGZPA",
-			AssetType:   "credit_alphanum4",
-			AssetID:     1229977787683536144,
-			ID:          -8205667356306085451,
-		},
-		AssetOutput{
-			AssetCode:   "",
-			AssetIssuer: "",
-			AssetType:   "native",
-			AssetID:     12638146518625398189,
-			ID:          -5706705804583548011,
-		},
-	}
-	return
-}
+// func makeAssetTestOutput() (transformedAssets []AssetOutput) {
+// 	transformedAssets = []AssetOutput{
+// 		AssetOutput{
+// 			AssetCode:   "USDT",
+// 			AssetIssuer: "GBVVRXLMNCJQW3IDDXC3X6XCH35B5Q7QXNMMFPENSOGUPQO7WO7HGZPA",
+// 			AssetType:   "credit_alphanum4",
+// 			AssetID:     1229977787683536144,
+// 			ID:          -8205667356306085451,
+// 		},
+// 		AssetOutput{
+// 			AssetCode:   "",
+// 			AssetIssuer: "",
+// 			AssetType:   "native",
+// 			AssetID:     12638146518625398189,
+// 			ID:          -5706705804583548011,
+// 		},
+// 	}
+// 	return
+// }

--- a/internal/transform/asset_test.go
+++ b/internal/transform/asset_test.go
@@ -6,37 +6,25 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/stellar/go/ingest"
 	"github.com/stellar/go/xdr"
 )
 
 func TestTransformAsset(t *testing.T) {
-	// type operationInput struct {
-	// 	operation   xdr.Operation
-	// 	index       int32
-	// 	transaction ingest.LedgerTransaction
-	// }
+
 	type assetInput struct {
 		operation xdr.Operation
 		index     int32
 		txnIndex  int32
 		// transaction xdr.TransactionEnvelope
 	}
-	// type transformTest struct {
-	// 	input      operationInput
-	// 	wantOutput AssetOutput
-	// 	wantErr    error
-	// }
+
 	type transformTest struct {
 		input      assetInput
 		wantOutput AssetOutput
 		wantErr    error
 	}
 
-	// nonPaymentInput := operationInput{
-	// 	operation:   genericBumpOperation,
-	// 	transaction: genericLedgerTransaction,
-	// 	index:       0,
-	// }
 	nonPaymentInput := assetInput{
 		operation: genericBumpOperation,
 		txnIndex:  0,
@@ -51,17 +39,20 @@ func TestTransformAsset(t *testing.T) {
 		},
 	}
 
-	// hardCodedInputTransaction, err := makeAssetTestInput()
-	// assert.NoError(t, err)
-	// hardCodedOutputArray := makeAssetTestOutput()
+	hardCodedInputTransaction, err := makeAssetTestInput()
+	assert.NoError(t, err)
+	hardCodedOutputArray := makeAssetTestOutput()
 
-	// for i, op := range hardCodedInputTransaction.Envelope.Operations() {
-	// 	tests = append(tests, transformTest{
-	// 		input:      operationInput{op, int32(i), hardCodedInputTransaction},
-	// 		wantOutput: hardCodedOutputArray[i],
-	// 		wantErr:    nil,
-	// 	})
-	// }
+	for i, op := range hardCodedInputTransaction.Envelope.Operations() {
+		tests = append(tests, transformTest{
+			input: assetInput{
+				operation: op,
+				index:     int32(i),
+				txnIndex:  int32(i)},
+			wantOutput: hardCodedOutputArray[i],
+			wantErr:    nil,
+		})
+	}
 
 	for _, test := range tests {
 		actualOutput, actualError := TransformAsset(test.input.operation, test.input.index, test.input.txnIndex, 0)
@@ -70,58 +61,58 @@ func TestTransformAsset(t *testing.T) {
 	}
 }
 
-// func makeAssetTestInput() (inputTransaction ingest.LedgerTransaction, err error) {
-// 	inputTransaction = genericLedgerTransaction
-// 	inputEnvelope := genericBumpOperationEnvelope
+func makeAssetTestInput() (inputTransaction ingest.LedgerTransaction, err error) {
+	inputTransaction = genericLedgerTransaction
+	inputEnvelope := genericBumpOperationEnvelope
 
-// 	inputEnvelope.Tx.SourceAccount = testAccount1
+	inputEnvelope.Tx.SourceAccount = testAccount1
 
-// 	inputOperations := []xdr.Operation{
-// 		xdr.Operation{
-// 			SourceAccount: nil,
-// 			Body: xdr.OperationBody{
-// 				Type: xdr.OperationTypePayment,
-// 				PaymentOp: &xdr.PaymentOp{
-// 					Destination: testAccount2,
-// 					Asset:       usdtAsset,
-// 					Amount:      350000000,
-// 				},
-// 			},
-// 		},
-// 		xdr.Operation{
-// 			SourceAccount: nil,
-// 			Body: xdr.OperationBody{
-// 				Type: xdr.OperationTypePayment,
-// 				PaymentOp: &xdr.PaymentOp{
-// 					Destination: testAccount3,
-// 					Asset:       nativeAsset,
-// 					Amount:      350000000,
-// 				},
-// 			},
-// 		},
-// 	}
+	inputOperations := []xdr.Operation{
+		xdr.Operation{
+			SourceAccount: nil,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypePayment,
+				PaymentOp: &xdr.PaymentOp{
+					Destination: testAccount2,
+					Asset:       usdtAsset,
+					Amount:      350000000,
+				},
+			},
+		},
+		xdr.Operation{
+			SourceAccount: nil,
+			Body: xdr.OperationBody{
+				Type: xdr.OperationTypePayment,
+				PaymentOp: &xdr.PaymentOp{
+					Destination: testAccount3,
+					Asset:       nativeAsset,
+					Amount:      350000000,
+				},
+			},
+		},
+	}
 
-// 	inputEnvelope.Tx.Operations = inputOperations
-// 	inputTransaction.Envelope.V1 = &inputEnvelope
-// 	return
-// }
+	inputEnvelope.Tx.Operations = inputOperations
+	inputTransaction.Envelope.V1 = &inputEnvelope
+	return
+}
 
-// func makeAssetTestOutput() (transformedAssets []AssetOutput) {
-// 	transformedAssets = []AssetOutput{
-// 		AssetOutput{
-// 			AssetCode:   "USDT",
-// 			AssetIssuer: "GBVVRXLMNCJQW3IDDXC3X6XCH35B5Q7QXNMMFPENSOGUPQO7WO7HGZPA",
-// 			AssetType:   "credit_alphanum4",
-// 			AssetID:     1229977787683536144,
-// 			ID:          -8205667356306085451,
-// 		},
-// 		AssetOutput{
-// 			AssetCode:   "",
-// 			AssetIssuer: "",
-// 			AssetType:   "native",
-// 			AssetID:     12638146518625398189,
-// 			ID:          -5706705804583548011,
-// 		},
-// 	}
-// 	return
-// }
+func makeAssetTestOutput() (transformedAssets []AssetOutput) {
+	transformedAssets = []AssetOutput{
+		AssetOutput{
+			AssetCode:   "USDT",
+			AssetIssuer: "GBVVRXLMNCJQW3IDDXC3X6XCH35B5Q7QXNMMFPENSOGUPQO7WO7HGZPA",
+			AssetType:   "credit_alphanum4",
+			AssetID:     1229977787683536144,
+			ID:          -8205667356306085451,
+		},
+		AssetOutput{
+			AssetCode:   "",
+			AssetIssuer: "",
+			AssetType:   "native",
+			AssetID:     12638146518625398189,
+			ID:          -5706705804583548011,
+		},
+	}
+	return
+}

--- a/internal/transform/ledger.go
+++ b/internal/transform/ledger.go
@@ -82,7 +82,7 @@ func TransformLedger(inputLedger historyarchive.Ledger) (LedgerOutput, error) {
 }
 
 func extractCounts(ledger historyarchive.Ledger) (transactionCount int32, operationCount int32, successTxCount int32, failedTxCount int32, txSetOperationCount string, err error) {
-	transactions := getTransactionSet(ledger)
+	transactions := GetTransactionSet(ledger)
 	results := ledger.TransactionResult.TxResultSet.Results
 	txCount := len(transactions)
 	if txCount != len(results) {
@@ -117,7 +117,7 @@ func extractCounts(ledger historyarchive.Ledger) (transactionCount int32, operat
 
 }
 
-func getTransactionSet(transactionEntry historyarchive.Ledger) (transactionProcessing []xdr.TransactionEnvelope) {
+func GetTransactionSet(transactionEntry historyarchive.Ledger) (transactionProcessing []xdr.TransactionEnvelope) {
 	switch transactionEntry.Transaction.Ext.V {
 	case 0:
 		return transactionEntry.Transaction.TxSet.Txs


### PR DESCRIPTION
Asset backend needs to use `historyarchive` instead of `ledgerbackend` to read transactions