### PR TITLE
doc : commented functions in cmd and internal/input folder  

### DIFF
--- a/cmd/export_config_setting.go
+++ b/cmd/export_config_setting.go
@@ -16,7 +16,10 @@ import (
 var configSettingCmd = &cobra.Command{
 	Use:   "export_config_setting",
 	Short: "Exports the config setting information.",
-	Long:  ``,
+	Long:  `Exports historical config settings data from the genesis ledger to the provided end-ledger to an output file. 
+	The command reads from the bucket list, which includes the full history of the Stellar ledger. As a result, it 
+	should be used in an initial data dump. In order to get offer information within a specified ledger range, see 
+	the export_ledger_entry_changes command.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmdLogger.SetLevel(logrus.InfoLevel)
 		endNum, strictExport, isTest, isFuture, extra := utils.MustCommonFlags(cmd.Flags(), cmdLogger)

--- a/cmd/export_contract_code.go
+++ b/cmd/export_contract_code.go
@@ -16,7 +16,10 @@ import (
 var codeCmd = &cobra.Command{
 	Use:   "export_contract_code",
 	Short: "Exports the contract code information.",
-	Long:  ``,
+	Long:  `Exports historical contract code data from the genesis ledger to the provided end-ledger to an output file. 
+	The command reads from the bucket list, which includes the full history of the Stellar ledger. As a result, it 
+	should be used in an initial data dump. In order to get offer information within a specified ledger range, see 
+	the export_ledger_entry_changes command.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmdLogger.SetLevel(logrus.InfoLevel)
 		endNum, strictExport, isTest, isFuture, extra := utils.MustCommonFlags(cmd.Flags(), cmdLogger)

--- a/cmd/export_contract_data.go
+++ b/cmd/export_contract_data.go
@@ -15,8 +15,11 @@ import (
 
 var dataCmd = &cobra.Command{
 	Use:   "export_contract_data",
-	Short: "Exports the contract data information.",
-	Long:  ``,
+	Short: "Exports the contract data information made from the genesis ledger to a specified endpoint.",
+	Long:  `Exports historical contract data from the genesis ledger to the provided end-ledger to an output file. 
+	The command reads from the bucket list, which includes the full history of the Stellar ledger. As a result, it 
+	should be used in an initial data dump. In order to get offer information within a specified ledger range, see 
+	the export_ledger_entry_changes command.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmdLogger.SetLevel(logrus.InfoLevel)
 		endNum, strictExport, isTest, isFuture, extra := utils.MustCommonFlags(cmd.Flags(), cmdLogger)

--- a/cmd/export_effects.go
+++ b/cmd/export_effects.go
@@ -11,6 +11,7 @@ import (
 var effectsCmd = &cobra.Command{
 	Use:   "export_effects",
 	Short: "Exports the effects data over a specified range",
+	Long: "Exports the effects data over a specified range to an output file."
 	Run: func(cmd *cobra.Command, args []string) {
 		cmdLogger.SetLevel(logrus.InfoLevel)
 		endNum, strictExport, isTest, isFuture, extra := utils.MustCommonFlags(cmd.Flags(), cmdLogger)

--- a/cmd/export_ttl.go
+++ b/cmd/export_ttl.go
@@ -16,7 +16,10 @@ import (
 var ttlCmd = &cobra.Command{
 	Use:   "export_ttl",
 	Short: "Exports the ttl information.",
-	Long:  ``,
+	Long:  `Exports historical ttl data from the genesis ledger to the provided end-ledger to an output file. 
+	The command reads from the bucket list, which includes the full history of the Stellar ledger. As a result, it 
+	should be used in an initial data dump. In order to get offer information within a specified ledger range, see 
+	the export_ledger_entry_changes command.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmdLogger.SetLevel(logrus.InfoLevel)
 		endNum, strictExport, isTest, isFuture, extra := utils.MustCommonFlags(cmd.Flags(), cmdLogger)

--- a/internal/input/bucketlist_entries.go
+++ b/internal/input/bucketlist_entries.go
@@ -35,6 +35,7 @@ func GetEntriesFromGenesis(end uint32, entryType xdr.LedgerEntryType, archiveURL
 	return readBucketList(archive, checkpointSeq, entryType)
 }
 
+// readBucketList reads the bucket list for the specified checkpoint sequence number and returns a slice of ledger entries of the specified type
 func readBucketList(archive historyarchive.ArchiveInterface, checkpointSeq uint32, entryType xdr.LedgerEntryType) ([]ingest.Change, error) {
 	changeReader, err := ingest.NewCheckpointChangeReader(context.Background(), archive, checkpointSeq)
 	defer changeReader.Close()

--- a/internal/input/orderbooks.go
+++ b/internal/input/orderbooks.go
@@ -33,6 +33,7 @@ type OrderbookParser struct {
 	Logger            *utils.EtlLogger
 }
 
+// convertOffer converts an offer to its normalized form and adds it to the AllConvertedOffers
 func (o *OrderbookParser) convertOffer(allConvertedOffers []transform.NormalizedOfferOutput, index int, offer ingest.Change, seq uint32, wg *sync.WaitGroup) {
 	defer wg.Done()
 	transformed, err := transform.TransformOfferNormalized(offer, seq)
@@ -44,6 +45,7 @@ func (o *OrderbookParser) convertOffer(allConvertedOffers []transform.Normalized
 	}
 }
 
+// NewOrderbookParser creates a new orderbook parser and returns it
 func NewOrderbookParser(logger *utils.EtlLogger) OrderbookParser {
 	return OrderbookParser{
 		Events:            make([][]byte, 0),
@@ -56,6 +58,7 @@ func NewOrderbookParser(logger *utils.EtlLogger) OrderbookParser {
 		Logger:            logger,
 	}
 }
+
 
 func (o *OrderbookParser) parseOrderbook(orderbook []ingest.Change, seq uint32) {
 	var group sync.WaitGroup

--- a/internal/input/trades.go
+++ b/internal/input/trades.go
@@ -80,6 +80,7 @@ func GetTrades(start, end uint32, limit int64, env utils.EnvironmentDetails) ([]
 	return tradeSlice, nil
 }
 
+// operationResultsInTrade returns true if the operation results in a trade
 func operationResultsInTrade(operation xdr.Operation) bool {
 	switch operation.Body.Type {
 	case xdr.OperationTypeManageBuyOffer:


### PR DESCRIPTION
added "long" descriptions to the functions in cmd:
* export_config_setting
*  export_contract_code
*  export_contract_data
*  export_effects
*  export_ttl

functions commented in internal/input: 
*  readBucketList
*  convertOffer
*  NewOrderbookParser
*  operationResultsInTrade