### PR TITLE
use NewLedgerChangeReaderFromLedgerCloseMeta

### DIFF
--- a/internal/input/transactions.go
+++ b/internal/input/transactions.go
@@ -38,7 +38,7 @@ func GetTransactions(start, end uint32, limit int64, env utils.EnvironmentDetail
 			return nil, errors.Wrap(err, "error getting ledger from the backend")
 		}
 
-		txReader, err := ingest.NewLedgerChangeReaderFromLedgerCloseMeta(env.NetworkPassphrase, ledgerCloseMeta)
+		txReader, err := ingest.NewLedgerTransactionReaderFromLedgerCloseMeta(env.NetworkPassphrase, ledgerCloseMeta)
 		if err != nil {
 			return []LedgerTransformInput{}, err
 		}


### PR DESCRIPTION
would it be more efficient to use NewLedgerTransactionReaderFromLedgerCloseMeta?  feel free to close this if the PR doesn't make sense. Thanks.