### PR TITLE
Add case for null operationResultTr for operation_trace_code

### DIFF
--- a/internal/transform/operation.go
+++ b/internal/transform/operation.go
@@ -70,10 +70,15 @@ func TransformOperation(operation xdr.Operation, operationIndex int32, transacti
 	if !ok {
 		return OperationOutput{}, err
 	}
+
 	outputOperationResultCode := outputOperationResults[operationIndex].Code.String()
-	outputOperationTraceCode, err := mapOperationTrace(*outputOperationResults[operationIndex].Tr)
-	if err != nil {
-		return OperationOutput{}, err
+	var outputOperationTraceCode string
+	operationResultTr, ok := outputOperationResults[operationIndex].GetTr()
+	if ok {
+		outputOperationTraceCode, err = mapOperationTrace(operationResultTr)
+		if err != nil {
+			return OperationOutput{}, err
+		}
 	}
 
 	transformedOperation := OperationOutput{


### PR DESCRIPTION
Not every operationResult in operationResults has a trace. This was causing a trying to dereference null error and needs a check to make stellar-etl work correctly