### PR TITLE
Release drafter and publisher

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,5 @@
+template: |
+  ## What's Changed
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,5 +1,0 @@
-template: |
-  ## What's Changed
-  $CHANGES
-
-  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,5 @@
+template: |
+  ## What's Changed
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: release-drafter/release-drafter@v5
         with:
           commitish: master
-          name: "stellar-dbt ${{ steps.gettag.outputs.TAG }}"
+          name: "stellar-etl ${{ steps.gettag.outputs.TAG }}"
           tag: ${{ github.ref }}
           publish: true
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release Drafter and Publisher
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: read
+
+jobs:
+  new_release:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # ${{ github.ref }} was not giving v* as tag name, but refs/tags/v* instead, so I had to abbreviate it
+      - name: Get latest abbreviated tag
+        id: gettag
+        run: echo ::set-output name=TAG::$(git describe --tags --abbrev=7)
+
+      - uses: release-drafter/release-drafter@v5
+        with:
+          commitish: master
+          name: "stellar-dbt ${{ steps.gettag.outputs.TAG }}"
+          tag: ${{ github.ref }}
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Everytime there is a new pushed tag in any branch in the repository, the process of publishing the release based on that tag starts. That way, the tag can be used to create a release, and also add new functionalities and patches.

It was designed based on semantic versioning: major.minor.patches . v1.0.0, v1.0.1, v0.1.1.