### PR TITLE
Add `ledger_key_hash` to `history_operations`

### DIFF
--- a/internal/transform/operation.go
+++ b/internal/transform/operation.go
@@ -1792,22 +1792,21 @@ func contractCodeHashFromTxEnvelope(transactionEnvelope xdr.TransactionV1Envelop
 	return ""
 }
 
-func ledgerKeyHashFromTxEnvelope(transactionEnvelope xdr.TransactionV1Envelope) string {
+func ledgerKeyHashFromTxEnvelope(transactionEnvelope xdr.TransactionV1Envelope) []string {
+	var ledgerKeyHash []string
 	for _, ledgerKey := range transactionEnvelope.Tx.Ext.SorobanData.Resources.Footprint.ReadOnly {
-		ledgerKeyHash := utils.LedgerKeyToLedgerKeyHash(ledgerKey)
-		if ledgerKeyHash != "" {
-			return ledgerKeyHash
+		if utils.LedgerKeyToLedgerKeyHash(ledgerKey) != "" {
+			ledgerKeyHash = append(ledgerKeyHash, utils.LedgerKeyToLedgerKeyHash(ledgerKey))
 		}
 	}
 
 	for _, ledgerKey := range transactionEnvelope.Tx.Ext.SorobanData.Resources.Footprint.ReadWrite {
-		ledgerKeyHash := utils.LedgerKeyToLedgerKeyHash(ledgerKey)
-		if ledgerKeyHash != "" {
-			return ledgerKeyHash
+		if utils.LedgerKeyToLedgerKeyHash(ledgerKey) != "" {
+			ledgerKeyHash = append(ledgerKeyHash, utils.LedgerKeyToLedgerKeyHash(ledgerKey))
 		}
 	}
 
-	return ""
+	return ledgerKeyHash
 }
 
 func contractCodeFromContractData(ledgerKey xdr.LedgerKey) string {

--- a/internal/transform/operation.go
+++ b/internal/transform/operation.go
@@ -1782,6 +1782,24 @@ func contractCodeHashFromTxEnvelope(transactionEnvelope xdr.TransactionV1Envelop
 	return ""
 }
 
+func ledgerKeyHashFromTxEnvelope(transactionEnvelope xdr.TransactionV1Envelope) string {
+	for _, ledgerKey := range transactionEnvelope.Tx.Ext.SorobanData.Resources.Footprint.ReadOnly {
+		ledgerKeyHash := utils.LedgerKeyToLedgerKeyHash(ledgerKey)
+		if ledgerKeyHash != "" {
+			return ledgerKeyHash
+		}
+	}
+
+	for _, ledgerKey := range transactionEnvelope.Tx.Ext.SorobanData.Resources.Footprint.ReadWrite {
+		ledgerKeyHash := utils.LedgerKeyToLedgerKeyHash(ledgerKey)
+		if ledgerKeyHash != "" {
+			return ledgerKeyHash
+		}
+	}
+
+	return ""
+}
+
 func contractCodeFromContractData(ledgerKey xdr.LedgerKey) string {
 	contractCode, ok := ledgerKey.GetContractCode()
 	if !ok {

--- a/internal/transform/operation.go
+++ b/internal/transform/operation.go
@@ -1031,6 +1031,7 @@ func extractOperationDetails(operation xdr.Operation, transaction ingest.LedgerT
 			details["type"] = "invoke_contract"
 
 			transactionEnvelope := getTransactionV1Envelope(transaction.Envelope)
+			details["ledger_key_hash"] = ledgerKeyHashFromTxEnvelope(transactionEnvelope)
 			details["contract_id"] = contractIdFromTxEnvelope(transactionEnvelope)
 			details["contract_code_hash"] = contractCodeHashFromTxEnvelope(transactionEnvelope)
 
@@ -1068,6 +1069,7 @@ func extractOperationDetails(operation xdr.Operation, transaction ingest.LedgerT
 			details["type"] = "create_contract"
 
 			transactionEnvelope := getTransactionV1Envelope(transaction.Envelope)
+			details["ledger_key_hash"] = ledgerKeyHashFromTxEnvelope(transactionEnvelope)
 			details["contract_id"] = contractIdFromTxEnvelope(transactionEnvelope)
 			details["contract_code_hash"] = contractCodeHashFromTxEnvelope(transactionEnvelope)
 
@@ -1089,6 +1091,7 @@ func extractOperationDetails(operation xdr.Operation, transaction ingest.LedgerT
 		case xdr.HostFunctionTypeHostFunctionTypeUploadContractWasm:
 			details["type"] = "upload_wasm"
 			transactionEnvelope := getTransactionV1Envelope(transaction.Envelope)
+			details["ledger_key_hash"] = ledgerKeyHashFromTxEnvelope(transactionEnvelope)
 			details["contract_code_hash"] = contractCodeHashFromTxEnvelope(transactionEnvelope)
 		default:
 			panic(fmt.Errorf("unknown host function type: %s", op.HostFunction.Type))
@@ -1099,12 +1102,14 @@ func extractOperationDetails(operation xdr.Operation, transaction ingest.LedgerT
 		details["extend_to"] = op.ExtendTo
 
 		transactionEnvelope := getTransactionV1Envelope(transaction.Envelope)
+		details["ledger_key_hash"] = ledgerKeyHashFromTxEnvelope(transactionEnvelope)
 		details["contract_id"] = contractIdFromTxEnvelope(transactionEnvelope)
 		details["contract_code_hash"] = contractCodeHashFromTxEnvelope(transactionEnvelope)
 	case xdr.OperationTypeRestoreFootprint:
 		details["type"] = "restore_footprint"
 
 		transactionEnvelope := getTransactionV1Envelope(transaction.Envelope)
+		details["ledger_key_hash"] = ledgerKeyHashFromTxEnvelope(transactionEnvelope)
 		details["contract_id"] = contractIdFromTxEnvelope(transactionEnvelope)
 		details["contract_code_hash"] = contractCodeHashFromTxEnvelope(transactionEnvelope)
 	default:
@@ -1629,6 +1634,7 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 			details["type"] = "invoke_contract"
 
 			transactionEnvelope := getTransactionV1Envelope(operation.transaction.Envelope)
+			details["ledger_key_hash"] = ledgerKeyHashFromTxEnvelope(transactionEnvelope)
 			details["contract_id"] = contractIdFromTxEnvelope(transactionEnvelope)
 			details["contract_code_hash"] = contractCodeHashFromTxEnvelope(transactionEnvelope)
 
@@ -1666,6 +1672,7 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 			details["type"] = "create_contract"
 
 			transactionEnvelope := getTransactionV1Envelope(operation.transaction.Envelope)
+			details["ledger_key_hash"] = ledgerKeyHashFromTxEnvelope(transactionEnvelope)
 			details["contract_id"] = contractIdFromTxEnvelope(transactionEnvelope)
 			details["contract_code_hash"] = contractCodeHashFromTxEnvelope(transactionEnvelope)
 
@@ -1687,6 +1694,7 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 		case xdr.HostFunctionTypeHostFunctionTypeUploadContractWasm:
 			details["type"] = "upload_wasm"
 			transactionEnvelope := getTransactionV1Envelope(operation.transaction.Envelope)
+			details["ledger_key_hash"] = ledgerKeyHashFromTxEnvelope(transactionEnvelope)
 			details["contract_code_hash"] = contractCodeHashFromTxEnvelope(transactionEnvelope)
 		default:
 			panic(fmt.Errorf("unknown host function type: %s", op.HostFunction.Type))
@@ -1697,12 +1705,14 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 		details["extend_to"] = op.ExtendTo
 
 		transactionEnvelope := getTransactionV1Envelope(operation.transaction.Envelope)
+		details["ledger_key_hash"] = ledgerKeyHashFromTxEnvelope(transactionEnvelope)
 		details["contract_id"] = contractIdFromTxEnvelope(transactionEnvelope)
 		details["contract_code_hash"] = contractCodeHashFromTxEnvelope(transactionEnvelope)
 	case xdr.OperationTypeRestoreFootprint:
 		details["type"] = "restore_footprint"
 
 		transactionEnvelope := getTransactionV1Envelope(operation.transaction.Envelope)
+		details["ledger_key_hash"] = ledgerKeyHashFromTxEnvelope(transactionEnvelope)
 		details["contract_id"] = contractIdFromTxEnvelope(transactionEnvelope)
 		details["contract_code_hash"] = contractCodeHashFromTxEnvelope(transactionEnvelope)
 	default:

--- a/internal/utils/main.go
+++ b/internal/utils/main.go
@@ -713,3 +713,11 @@ func LedgerEntryToLedgerKeyHash(ledgerEntry xdr.LedgerEntry) string {
 
 	return ledgerKeyHash
 }
+
+func LedgerKeyToLedgerKeyHash(ledgerKey xdr.LedgerKey) string {
+	ledgerKeyByte, _ := ledgerKey.MarshalBinary()
+	hashedLedgerKeyByte := hash.Hash(ledgerKeyByte)
+	ledgerKeyHash := hex.EncodeToString(hashedLedgerKeyByte[:])
+
+	return ledgerKeyHash
+}


### PR DESCRIPTION
This PR introduces a new field named `ledger_key_hash` to the `history_operations` export file. The field will only be included when the OperationType property is one of the following values:

- `InvokeHostFunction`
- `ExtendFootprintTtl`
- `RestoreFootprint`
