### PR TITLE
Feature/change workdir

### DIFF
--- a/cmd/export_ledger_entry_changes_test.go
+++ b/cmd/export_ledger_entry_changes_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 const coreExecutablePath = "../stellar-core/src/stellar-core"
-const coreConfigPath = "./docker/stellar-core.cfg"
+const coreConfigPath = "/etl/docker/stellar-core.cfg"
 
 func TestExportChanges(t *testing.T) {
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,9 @@ WORKDIR /etl
 COPY --from=build /usr/local/bin/stellar-etl /usr/local/bin/stellar-etl
 COPY --from=build /usr/src/etl/docker docker
 
+# changing workdir to a new path in order to use mounted empty ephemeral volumes as storage
+WORKDIR /etl/data
+
 # clear entrypoint from stellar-core image
 ENTRYPOINT []
 

--- a/internal/utils/main.go
+++ b/internal/utils/main.go
@@ -631,21 +631,21 @@ func GetEnvironmentDetails(isTest bool, isFuture bool) (details EnvironmentDetai
 		details.NetworkPassphrase = network.TestNetworkPassphrase
 		details.ArchiveURLs = testArchiveURLs
 		details.BinaryPath = "/usr/bin/stellar-core"
-		details.CoreConfig = "docker/stellar-core_testnet.cfg"
+		details.CoreConfig = "/etl/docker/stellar-core_testnet.cfg"
 		return details
 	} else if isFuture {
 		// details.NetworkPassphrase = network.FutureNetworkPassphrase
 		details.NetworkPassphrase = "Test SDF Future Network ; October 2022"
 		details.ArchiveURLs = futureArchiveURLs
 		details.BinaryPath = "/usr/bin/stellar-core"
-		details.CoreConfig = "docker/stellar-core_futurenet.cfg"
+		details.CoreConfig = "/etl/docker/stellar-core_futurenet.cfg"
 		return details
 	} else {
 		// default: mainnet
 		details.NetworkPassphrase = network.PublicNetworkPassphrase
 		details.ArchiveURLs = mainArchiveURLs
 		details.BinaryPath = "/usr/bin/stellar-core"
-		details.CoreConfig = "docker/stellar-core.cfg"
+		details.CoreConfig = "/etl/docker/stellar-core.cfg"
 		return details
 	}
 }


### PR DESCRIPTION
### Context
This PR aims to set the container `WORKDIR` on the image to a path not used in building stages that could be later mounted using ephemeral disks. The former path used is not suitable for the ephemeral volume mount mentioned since the building process persists data on it, and mounting an empty volume on this path would cause the container to lose the data required.
This change also requires the Stellar core configuration path to be adjusted for commands where the CoreConfig is not passed as an argument since it is gotten from environment details and later set to paths relative to the container `WORKDIR`. 

### Key Changes
- Changed docker `WORKDIR` to `/etl/data` from `/etl`
- Set the utils EnvironmentDetails values for `CoreConfig` to refer to the absolute path instead of the relative path.