### PR TITLE
Feature/disable xcom

### DIFF
--- a/cmd/get_ledger_range_from_times.go
+++ b/cmd/get_ledger_range_from_times.go
@@ -78,12 +78,9 @@ var getLedgerRangeFromTimesCmd = &cobra.Command{
 
 		if path != "" {
 			outFile := mustOutFile(path)
-			outFile.Write(marshalled)
-			outFile.WriteString("\n")
-
 			numFailures := 0
 			totalNumBytes := 0
-			numBytes, err := exportEntry(marshalled, outFile, nil)
+			numBytes, err := exportEntry(toExport, outFile, nil)
 			if err != nil {
 				cmdLogger.LogError(fmt.Errorf("could not export ledger ranges: %v", err))
 				numFailures += 1

--- a/cmd/get_ledger_range_from_times.go
+++ b/cmd/get_ledger_range_from_times.go
@@ -27,8 +27,6 @@ var getLedgerRangeFromTimesCmd = &cobra.Command{
 	range covers time before the network started, the ledger range will start with the genesis ledger.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmdLogger.SetLevel(logrus.InfoLevel)
-		commonArgs := utils.MustCommonFlags(cmd.Flags(), cmdLogger)
-		// _, path, _ := utils.MustArchiveFlags(cmd.Flags(), cmdLogger)
 		cloudStorageBucket, cloudCredentials, cloudProvider := utils.MustCloudStorageFlags(cmd.Flags(), cmdLogger)
 
 		startString, err := cmd.Flags().GetString("start-time")
@@ -85,7 +83,7 @@ var getLedgerRangeFromTimesCmd = &cobra.Command{
 
 			numFailures := 0
 			totalNumBytes := 0
-			numBytes, err := exportEntry(marshalled, outFile, commonArgs.Extra)
+			numBytes, err := exportEntry(marshalled, outFile, nil)
 			if err != nil {
 				cmdLogger.LogError(fmt.Errorf("could not export ledger ranges: %v", err))
 				numFailures += 1

--- a/cmd/get_ledger_range_from_times.go
+++ b/cmd/get_ledger_range_from_times.go
@@ -20,7 +20,7 @@ type ledgerRange struct {
 var getLedgerRangeFromTimesCmd = &cobra.Command{
 	Use:   "get_ledger_range_from_times",
 	Short: "Converts a time range into a ledger range",
-	Long: `Converts a time range into a ledger range. Times must be in the format YYYY-MM-DDTHH:MM:SS.SSSZ.
+	Long: `Converts a time range into a ledger range and then it exports the range to a path in GCS. Times must be in the format YYYY-MM-DDTHH:MM:SS.SSSZ.
 
 	Some examples include: 2006-01-02T15:04:05-07:00, 2009-11-10T18:00:00-05:00, or 2019-09-13T23:00:00+00:00.
 	If the time range goes into the future, the ledger range will end on the most recent ledger. If the time


### PR DESCRIPTION
In order to disable xcom and continue to test the functions related in stellar-et-airflow it is necessary to pass this PR.
This is the first step to disable xcom.
The idea is: We had the xcom with the values of start and end ledger. 
The process in this PR is that the values of start ledger and end ledger will be in a file exported to GCS, this way the time to generate xcom will be skipped and the ledger values will be stored in a place to be used by subsequent tasks.
The test is done and it was exported successfully like the image below:
![tests](https://github.com/stellar/stellar-etl/assets/46203330/447a251b-3b08-4c99-9c95-8c192084f8e4)
