### PR TITLE
Fix cross contract contract_id bug

### DIFF
--- a/internal/transform/operation.go
+++ b/internal/transform/operation.go
@@ -1030,9 +1030,14 @@ func extractOperationDetails(operation xdr.Operation, transaction ingest.LedgerT
 
 			details["type"] = "invoke_contract"
 
+			contractId, err := invokeArgs.ContractAddress.String()
+			if err != nil {
+				return nil, err
+			}
+
 			transactionEnvelope := getTransactionV1Envelope(transaction.Envelope)
 			details["ledger_key_hash"] = ledgerKeyHashFromTxEnvelope(transactionEnvelope)
-			details["contract_id"] = contractIdFromTxEnvelope(transactionEnvelope)
+			details["contract_id"] = contractId
 			details["contract_code_hash"] = contractCodeHashFromTxEnvelope(transactionEnvelope)
 
 			for _, param := range args {
@@ -1633,9 +1638,14 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 
 			details["type"] = "invoke_contract"
 
+			contractId, err := invokeArgs.ContractAddress.String()
+			if err != nil {
+				return nil, err
+			}
+
 			transactionEnvelope := getTransactionV1Envelope(operation.transaction.Envelope)
 			details["ledger_key_hash"] = ledgerKeyHashFromTxEnvelope(transactionEnvelope)
-			details["contract_id"] = contractIdFromTxEnvelope(transactionEnvelope)
+			details["contract_id"] = contractId
 			details["contract_code_hash"] = contractCodeHashFromTxEnvelope(transactionEnvelope)
 
 			for _, param := range args {


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [x] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

* [x] This PR adds tests for the most critical parts of the new functionality or fixes.
* [x] I've updated the README with the added features, breaking changes, new instructions on how to use the repository. I updated the description of the fuction with the changes that were made.

### Release planning

* [x] I've decided if this PR requires a new major/minor/patch version accordingly to
  [semver](https://semver.org/), and I've changed the name of the BRANCH to release/* , feature/* or patch/* . 
</details>

### What

stellar-etl invokeHostFunction invokeHost operations sometimes returned the incorrect contract_id in a cross contract invocation operation. This was updated to return the root contract_id that called the function instead of the first sorobanData contract_id. 

### Why

Return the expected and correct root `contract_id`

### Known limitations

N/A
