### PR TITLE
Update core image for consistency (no funcitonal change)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 RUN go build -v -o /usr/local/bin ./...
 
 # stage 2: runtime enviroment
-FROM stellar/unsafe-stellar-core:21.0.0-1812.rc1.a10329cca.focal
+FROM stellar/stellar-core:21.0.0-1872.c6f474133.focal
 
 WORKDIR /etl
 


### PR DESCRIPTION
Update core version. No functional changes as stellar-etl running for Hubble does not use the core image anymore