### PR TITLE
trilom bug

### DIFF
--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -23,7 +23,7 @@ jobs:
           go-version: 1
 
       - id: file_changes
-        uses: trilom/file-changes-action@v1.2.3
+        uses: trilom/file-changes-action@v1.2.4
         with:
           output: " "
 


### PR DESCRIPTION
### What

There is a bug in trilom, that fails the CI in the version v1.2.3. Updating to v1.2.4 solves the problem.

### Why

[Source](https://github.com/trilom/file-changes-action/issues/97)

### Known limitations

[N/A]
