### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# Require Horizon team reviews
-* @stellar/platform-committers
+# Require data team reviews
+* @stellar/platform-data-committers


### PR DESCRIPTION
Our codeowners file still referenced `platform-committers`, which is decommission. Updating the maintainers to the correct team.