### PR TITLE
Add instructions to build docker image locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BUILD_DATE := $(shell date -u +%FT%TZ)
 ETLHASH=stellar/stellar-etl:$(shell git rev-parse --short HEAD)
 
 docker-build:
-	$(SUDO) docker build --pull --no-cache --label org.opencontainers.image.created="$(BUILD_DATE)" \
+	$(SUDO) docker build --platform linux/amd64 --pull --no-cache --label org.opencontainers.image.created="$(BUILD_DATE)" \
 	-t $(ETLHASH) -t stellar/stellar-etl:latest -f ./docker/Dockerfile .
 
 docker-push:

--- a/README.md
+++ b/README.md
@@ -57,11 +57,14 @@ If branch is already made, just rename it _before passing the pull request_.
 2. Build stellar-etl with `go build`
 3. Build the docker image locally with `make docker-build`
 4. Run the docker container in interactive mode to run export commands.
+
 ```sh
 $ docker run --platform linux/amd64 -it stellar/stellar-etl:latest /bin/bash
 ```
+
 5. Run export commands to export information about the legder
-Example command to export ledger data
+   Example command to export ledger data
+
 ```sh
 root@71890b878fca:/etl/data# stellar-etl export_ledgers --start-ledger 1000 --end-ledger 500000 --output exported_ledgers.txt
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,16 @@ If branch is already made, just rename it _before passing the pull request_.
 
 1. Clone this repo `git clone https://github.com/stellar/stellar-etl`
 2. Build stellar-etl with `go build`
-3. Run export commands to export information about the legder
+3. Build the docker image locally with `make docker-build`
+4. Run the docker container in interactive mode to run export commands.
+```sh
+$ docker run --platform linux/amd64 -it stellar/stellar-etl:latest /bin/bash
+```
+5. Run export commands to export information about the legder
+Example command to export ledger data
+```sh
+root@71890b878fca:/etl/data# stellar-etl export_ledgers --start-ledger 1000 --end-ledger 500000 --output exported_ledgers.txt
+```
 
 > _*Note:*_ If using the GCS datastore, you can run the following to set GCP credentials to use in your shell
 
@@ -63,6 +72,12 @@ If branch is already made, just rename it _before passing the pull request_.
 gcloud auth login
 gcloud config set project dev-hubble
 gcloud auth application-default login
+```
+
+Add following to docker run command to pass gcloud credentials to docker container
+
+```
+-e GOOGLE_APPLICATION_CREDENTIALS=/.config/gcp/credentials.json -v "$HOME/.config/gcloud/application_default_credentials.json":/.config/gcp/credentials.json:ro
 ```
 
 > _*Note:*_ Instructions for installing gcloud can be found [here](https://cloud.google.com/sdk/docs/install-sdk)

--- a/internal/utils/main.go
+++ b/internal/utils/main.go
@@ -235,7 +235,7 @@ func AddCommonFlags(flags *pflag.FlagSet) {
 	flags.Bool("futurenet", false, "If set, will connect to Futurenet instead of Mainnet.")
 	flags.StringToStringP("extra-fields", "u", map[string]string{}, "Additional fields to append to output jsons. Used for appending metadata")
 	flags.Bool("captive-core", false, "If set, run captive core to retrieve data. Otherwise use TxMeta file datastore.")
-	flags.String("datastore-path", "sdf-ledger-close-metas/ledgers", "Datastore bucket path to read txmeta files from.")
+	flags.String("datastore-path", "sdf-ledger-close-meta/ledgers", "Datastore bucket path to read txmeta files from.")
 	flags.Uint32("buffer-size", 200, "Buffer size sets the max limit for the number of txmeta files that can be held in memory.")
 	flags.Uint32("num-workers", 10, "Number of workers to spawn that read txmeta files from the datastore.")
 	flags.Uint32("retry-limit", 3, "Datastore GetLedger retry limit.")


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository. I updated the description of the fuction with the changes that were made.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/_ , feature/_ or patch/\* .
</details>

### What

This PR adds following changes:
- Add instructions in README to build docker image locally and run export commands locally. This is helpful for local testing.
- Update docker-build command in Makefile to support Apple M1 chip. See https://stackoverflow.com/questions/66662820/m1-docker-preview-and-keycloak-images-platform-linux-amd64-does-not-match-th
- Update datastore path from `sdf-ledger-close-metas/ledgers` to `sdf-ledger-close-meta/ledgers` (Note the removed (s) in metas) 
   Context from slack:

   "We recently did a full history backfill for our datalake in GCS in bucket sdf-ledger-close-meta/ledgers
sdf-ledger-close-metas/ledgers is the old bucket. This was used as our frontfilling bucket but should be updated and changed in stellar-etl to the new full history data lake as the default bucket"

### Why

Covered in what section

### Known limitations

- [ ] Check with @chowbao a good way to test above non-doc changes
