### PR TITLE
Export index and id in history_effects table

### DIFF
--- a/internal/transform/effects.go
+++ b/internal/transform/effects.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/guregu/null"
 	"github.com/stellar/go/amount"
@@ -158,6 +159,8 @@ func (operation *transactionOperationWrapper) effects() ([]EffectOutput, error) 
 	for i := range wrapper.effects {
 		wrapper.effects[i].LedgerClosed = operation.ledgerClosed
 		wrapper.effects[i].LedgerSequence = operation.ledgerSequence
+		wrapper.effects[i].EffectIndex = uint32(i)
+		wrapper.effects[i].EffectId = strings.Join([]string{strconv.FormatInt(wrapper.effects[i].OperationID, 10), strconv.FormatUint(uint64(wrapper.effects[i].EffectIndex), 10)}, "-")
 	}
 
 	return wrapper.effects, nil

--- a/internal/transform/effects.go
+++ b/internal/transform/effects.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/guregu/null"
 	"github.com/stellar/go/amount"
@@ -160,7 +159,7 @@ func (operation *transactionOperationWrapper) effects() ([]EffectOutput, error) 
 		wrapper.effects[i].LedgerClosed = operation.ledgerClosed
 		wrapper.effects[i].LedgerSequence = operation.ledgerSequence
 		wrapper.effects[i].EffectIndex = uint32(i)
-		wrapper.effects[i].EffectId = strings.Join([]string{strconv.FormatInt(wrapper.effects[i].OperationID, 10), strconv.FormatUint(uint64(wrapper.effects[i].EffectIndex), 10)}, "-")
+		wrapper.effects[i].EffectId = fmt.Sprintf("%d-%d", wrapper.effects[i].OperationID, wrapper.effects[i].EffectIndex)
 	}
 
 	return wrapper.effects, nil

--- a/internal/transform/effects_test.go
+++ b/internal/transform/effects_test.go
@@ -3,6 +3,7 @@ package transform
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"math/big"
 	"strings"
 	"testing"
@@ -1738,6 +1739,10 @@ func TestOperationEffects(t *testing.T) {
 				ledgerSequence: tc.sequence,
 				ledgerClosed:   LedgerClosed,
 			}
+			for i := range tc.expected {
+				tc.expected[i].EffectIndex = uint32(i)
+				tc.expected[i].EffectId = fmt.Sprintf("%d-%d", tc.expected[i].OperationID, tc.expected[i].EffectIndex)
+			}
 
 			effects, err := operation.effects()
 			tt.NoError(err)
@@ -1882,6 +1887,11 @@ func TestOperationEffectsSetOptionsSignersOrder(t *testing.T) {
 			LedgerSequence: 46,
 		},
 	}
+	for i := range expected {
+		expected[i].EffectIndex = uint32(i)
+		expected[i].EffectId = fmt.Sprintf("%d-%d", expected[i].OperationID, expected[i].EffectIndex)
+	}
+
 	tt.Equal(expected, effects)
 }
 
@@ -2008,6 +2018,11 @@ func TestOperationEffectsSetOptionsSignersNoUpdated(t *testing.T) {
 			LedgerSequence: 46,
 		},
 	}
+	for i := range expected {
+		expected[i].EffectIndex = uint32(i)
+		expected[i].EffectId = fmt.Sprintf("%d-%d", expected[i].OperationID, expected[i].EffectIndex)
+	}
+
 	tt.Equal(expected, effects)
 }
 
@@ -2112,6 +2127,11 @@ func TestOperationEffectsAllowTrustAuthorizedToMaintainLiabilities(t *testing.T)
 			LedgerSequence: 1,
 		},
 	}
+	for i := range expected {
+		expected[i].EffectIndex = uint32(i)
+		expected[i].EffectId = fmt.Sprintf("%d-%d", expected[i].OperationID, expected[i].EffectIndex)
+	}
+
 	tt.Equal(expected, effects)
 }
 
@@ -2177,6 +2197,11 @@ func TestOperationEffectsClawback(t *testing.T) {
 			LedgerSequence: 1,
 		},
 	}
+	for i := range expected {
+		expected[i].EffectIndex = uint32(i)
+		expected[i].EffectId = fmt.Sprintf("%d-%d", expected[i].OperationID, expected[i].EffectIndex)
+	}
+
 	tt.Equal(expected, effects)
 }
 
@@ -2225,6 +2250,11 @@ func TestOperationEffectsClawbackClaimableBalance(t *testing.T) {
 			LedgerSequence: 1,
 		},
 	}
+	for i := range expected {
+		expected[i].EffectIndex = uint32(i)
+		expected[i].EffectId = fmt.Sprintf("%d-%d", expected[i].OperationID, expected[i].EffectIndex)
+	}
+
 	tt.Equal(expected, effects)
 }
 
@@ -2283,6 +2313,11 @@ func TestOperationEffectsSetTrustLineFlags(t *testing.T) {
 			LedgerSequence: 1,
 		},
 	}
+	for i := range expected {
+		expected[i].EffectIndex = uint32(i)
+		expected[i].EffectId = fmt.Sprintf("%d-%d", expected[i].OperationID, expected[i].EffectIndex)
+	}
+
 	tt.Equal(expected, effects)
 }
 
@@ -2483,6 +2518,10 @@ func TestTrustlineSponsorhipEffects(t *testing.T) {
 			LedgerClosed:   genericCloseTime.UTC(),
 			LedgerSequence: 1,
 		},
+	}
+	for i := range expected {
+		expected[i].EffectIndex = uint32(i)
+		expected[i].EffectId = fmt.Sprintf("%d-%d", expected[i].OperationID, expected[i].EffectIndex)
 	}
 
 	// pick an operation with no intrinsic effects
@@ -3169,6 +3208,11 @@ func TestLiquidityPoolEffects(t *testing.T) {
 			},
 		}
 
+		for i := range tc.expected {
+			tc.expected[i].EffectIndex = uint32(i)
+			tc.expected[i].EffectId = fmt.Sprintf("%d-%d", tc.expected[i].OperationID, tc.expected[i].EffectIndex)
+		}
+
 		t.Run(tc.desc, func(t *testing.T) {
 			operation := transactionOperationWrapper{
 				index:          0,
@@ -3785,6 +3829,11 @@ func TestInvokeHostFunctionEffects(t *testing.T) {
 				network:        networkPassphrase,
 			}
 
+			for i := range testCase.expected {
+				testCase.expected[i].EffectIndex = uint32(i)
+				testCase.expected[i].EffectId = fmt.Sprintf("%d-%d", testCase.expected[i].OperationID, testCase.expected[i].EffectIndex)
+			}
+
 			effects, err := operation.effects()
 			assert.NoErrorf(t, err, "event type %v", testCase.eventType)
 			assert.Lenf(t, effects, len(testCase.expected), "event type %v", testCase.eventType)
@@ -3970,6 +4019,8 @@ func TestBumpFootprintExpirationEffects(t *testing.T) {
 				TypeString:     EffectTypeNames[EffectExtendFootprintTtl],
 				LedgerClosed:   time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
 				LedgerSequence: 1,
+				EffectIndex:    0,
+				EffectId:       fmt.Sprintf("%d-%d", toid.New(1, 0, 1).ToInt64(), 0),
 			},
 		},
 		effects,
@@ -4085,6 +4136,8 @@ func TestAddRestoreFootprintExpirationEffect(t *testing.T) {
 				TypeString:     EffectTypeNames[EffectRestoreFootprint],
 				LedgerClosed:   time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
 				LedgerSequence: 1,
+				EffectIndex:    0,
+				EffectId:       fmt.Sprintf("%d-%d", toid.New(1, 0, 1).ToInt64(), 0),
 			},
 		},
 		effects,

--- a/internal/transform/schema.go
+++ b/internal/transform/schema.go
@@ -355,6 +355,8 @@ type EffectOutput struct {
 	TypeString     string                 `json:"type_string"`
 	LedgerClosed   time.Time              `json:"closed_at"`
 	LedgerSequence uint32                 `json:"ledger_sequence"`
+	EffectIndex    uint32                 `json:"index"`
+	EffectId       string                 `json:"id"`
 }
 
 // EffectType is the numeric type for an effect


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [x] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository. I updated the description of the fuction with the changes that were made.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/_ , feature/_ or patch/\* .
</details>

### What

This PR exports two additional params for operation effects:
- Effect Index - These are generated in order for each operation
- Effect id - This is essentially concatenation of `operation_id-effect_index`

### Why

To keep data parity between Horizon and Hubble. Read https://stellarorg.atlassian.net/browse/HUBBLE-460

### Known limitations

None


I additionally tested using docker container to ensure above props are getting outputted. Sample output below:

```
root@af62b592b099:/etl/data# stellar-etl export_effects --start-ledger 1000 \
> --end-ledger 10000 --output exported_effects.txt
INFO[2024-07-10T00:17:33.122Z] Number of bytes written: 6442                 pid=9
INFO[2024-07-10T00:17:33.125Z] {"attempted_transforms":8,"failed_transforms":0,"successful_transforms":8}  pid=9
INFO[2024-07-10T00:17:33.125Z] No cloud provider specified for upload. Skipping upload.  pid=9
root@af62b592b099:/etl/data# head exported_effects.txt
{"address":"GAP2KHWUMOHY7IO37UJY7SEBIITJIDZS5DRIIQRPEUT4VUKHZQGIRWS4","address_muxed":null,"closed_at":"2015-10-01T04:15:01Z","details":{"starting_balance":"20.0000000"},"id":"33676838572033-0","index":0,"ledger_sequence":7841,"operation_id":33676838572033,"type":0,"type_string":"account_created"}
{"address":"GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB","address_muxed":null,"closed_at":"2015-10-01T04:15:01Z","details":{"amount":"20.0000000","asset_type":"native"},"id":"33676838572033-1","index":1,"ledger_sequence":7841,"operation_id":33676838572033,"type":3,"type_string":"account_debited"}
{"address":"GAP2KHWUMOHY7IO37UJY7SEBIITJIDZS5DRIIQRPEUT4VUKHZQGIRWS4","address_muxed":null,"closed_at":"2015-10-01T04:15:01Z","details":{"public_key":"GAP2KHWUMOHY7IO37UJY7SEBIITJIDZS5DRIIQRPEUT4VUKHZQGIRWS4","weight":1},"id":"33676838572033-2","index":2,"ledger_sequence":7841,"operation_id":33676838572033,"type":10,"type_string":"signer_created"}
{"address":"GCZTBYH66ISTZKUPVJWTMHWBH4S4JIJ7WNLQJXCTQJKWY3FIT34BWZCJ","address_muxed":null,"closed_at":"2015-10-01T04:15:01Z","details":{"starting_balance":"20.0000000"},"id":"33676838572034-0","index":0,"ledger_sequence":7841,"operation_id":33676838572034,"type":0,"type_string":"account_created"}
{"address":"GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB","address_muxed":null,"closed_at":"2015-10-01T04:15:01Z","details":{"amount":"20.0000000","asset_type":"native"},"id":"33676838572034-1","index":1,"ledger_sequence":7841,"operation_id":33676838572034,"type":3,"type_string":"account_debited"}
{"address":"GCZTBYH66ISTZKUPVJWTMHWBH4S4JIJ7WNLQJXCTQJKWY3FIT34BWZCJ","address_muxed":null,"closed_at":"2015-10-01T04:15:01Z","details":{"public_key":"GCZTBYH66ISTZKUPVJWTMHWBH4S4JIJ7WNLQJXCTQJKWY3FIT34BWZCJ","weight":1},"id":"33676838572034-2","index":2,"ledger_sequence":7841,"operation_id":33676838572034,"type":10,"type_string":"signer_created"}
{"address":"GBEZOC5U4TVH7ZY5N3FLYHTCZSI6VFGTULG7PBITLF5ZEBPJXFT46YZM","address_muxed":null,"closed_at":"2015-10-01T04:15:01Z","details":{"starting_balance":"20.0000000"},"id":"33676838572035-0","index":0,"ledger_sequence":7841,"operation_id":33676838572035,"type":0,"type_string":"account_created"}
{"address":"GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB","address_muxed":null,"closed_at":"2015-10-01T04:15:01Z","details":{"amount":"20.0000000","asset_type":"native"},"id":"33676838572035-1","index":1,"ledger_sequence":7841,"operation_id":33676838572035,"type":3,"type_string":"account_debited"}
{"address":"GBEZOC5U4TVH7ZY5N3FLYHTCZSI6VFGTULG7PBITLF5ZEBPJXFT46YZM","address_muxed":null,"closed_at":"2015-10-01T04:15:01Z","details":{"public_key":"GBEZOC5U4TVH7ZY5N3FLYHTCZSI6VFGTULG7PBITLF5ZEBPJXFT46YZM","weight":1},"id":"33676838572035-2","index":2,"ledger_sequence":7841,"operation_id":33676838572035,"type":10,"type_string":"signer_created"}
{"address":"GALPCCZN4YXA3YMJHKL6CVIECKPLJJCTVMSNYWBTKJW4K5HQLYLDMZTB","address_muxed":null,"closed_at":"2015-10-01T04:16:11Z","details":{"inflation_destination":"GAP2KHWUMOHY7IO37UJY7SEBIITJIDZS5DRIIQRPEUT4VUKHZQGIRWS4"},"id":"33736968114177-0","index":0,"ledger_sequence":7855,"operation_id":33736968114177,"type":7,"type_string":"account_inflation_destination_updated"}
```