### PR TITLE
Update bugs related to transaction fees

### DIFF
--- a/internal/transform/transaction.go
+++ b/internal/transform/transaction.go
@@ -170,8 +170,7 @@ func TransformTransaction(transaction ingest.LedgerTransaction, lhe xdr.LedgerHe
 
 		meta, ok := transaction.UnsafeMeta.GetV3()
 		if ok {
-			accountBalanceStart, _ := getAccountBalanceFromLedgerEntryChanges(meta.TxChangesBefore, feeAccountAddress)
-			_, accountBalanceEnd := getAccountBalanceFromLedgerEntryChanges(meta.TxChangesAfter, feeAccountAddress)
+			accountBalanceStart, accountBalanceEnd := getAccountBalanceFromLedgerEntryChanges(meta.TxChangesAfter, feeAccountAddress)
 			outputResourceFeeRefund = accountBalanceEnd - accountBalanceStart
 			if meta.SorobanMeta != nil {
 				extV1, ok := meta.SorobanMeta.Ext.GetV1()


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository. I updated the description of the fuction with the changes that were made.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/_ , feature/_ or patch/\* .
</details>

### What

There were a couple bugs for transaction fees
* Transaction fees were negative due to not using the correct feeAccount for fee bump transactions
* The feeCharged amount was fixed in P21 so there needs to be logic handling the correct calculation of feeCharged for <P21 only

Note that for Fee bump transactions `feeAccount` can be the same as `sourceAccount`

[Slack thread for more context](https://stellarfoundation.slack.com/archives/C073MNCNVQQ/p1724775798298019)

### Why

To correctly report transaction fees

### Known limitations

Will need to backfill history_transactions to get correct fees data
