### PR TITLE
Add check for GCS file upload exist

### DIFF
--- a/cmd/upload_to_gcs.go
+++ b/cmd/upload_to_gcs.go
@@ -58,6 +58,14 @@ func (g *GCS) UploadTo(credentialsPath, bucket, path string) error {
 		return err
 	}
 
+	// This is a possibly redundant check to make sure that the file is actually
+	// uploaded to GCS and is readable
+	pathObj := client.Bucket(bucket).Object(path)
+	_, err = pathObj.Attrs(ctx)
+	if err != nil {
+		return fmt.Errorf("uploaded file does not exist: %v", err)
+	}
+
 	cmdLogger.Infof("Successfully uploaded %d bytes to gs://%s/%s", written, bucket, path)
 
 	deleteLocalFiles(path)


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository. I updated the description of the fuction with the changes that were made.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/_ , feature/_ or patch/\* .
</details>

### What

Adding a check to see if the stellar-etl exported data file was actually upload and exists in GCS by checking for the file in GCS.

### Why

There have been times that the stellar-etl task in airflow has failed to upload a file to GCS and did not fail the task. This should prevent that scenario from happening again.

### Known limitations

It is in theory a redundant check but performance impact is negligible 
