### PR TITLE
Fix logging issues in stellar-etl writing to airflow

### DIFF
--- a/cmd/command_utils.go
+++ b/cmd/command_utils.go
@@ -127,7 +127,7 @@ func maybeUpload(cloudCredentials, cloudStorageBucket, cloudProvider, path strin
 	}
 
 	if len(cloudStorageBucket) == 0 {
-		cmdLogger.Error("No bucket specified")
+		cmdLogger.Fatal("No bucket specified")
 		return
 	}
 
@@ -137,11 +137,11 @@ func maybeUpload(cloudCredentials, cloudStorageBucket, cloudProvider, path strin
 		cloudStorage = newGCS(cloudCredentials, cloudStorageBucket)
 		err := cloudStorage.UploadTo(cloudCredentials, cloudStorageBucket, path)
 		if err != nil {
-			cmdLogger.Errorf("Unable to upload output to GCS: %s", err)
+			cmdLogger.Fatalf("Unable to upload output to GCS: %s", err)
 			return
 		}
 	default:
-		cmdLogger.Error("Unknown cloud provider")
+		cmdLogger.Fatal("Unknown cloud provider")
 	}
 }
 

--- a/cmd/export_assets.go
+++ b/cmd/export_assets.go
@@ -58,7 +58,7 @@ var assetsCmd = &cobra.Command{
 			seenIDs[transformed.AssetID] = true
 			numBytes, err := exportEntry(transformed, outFile, commonArgs.Extra)
 			if err != nil {
-				cmdLogger.Error(err)
+				cmdLogger.LogError(err)
 				numFailures += 1
 				continue
 			}

--- a/cmd/export_effects.go
+++ b/cmd/export_effects.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/stellar/stellar-etl/internal/input"
@@ -34,7 +36,7 @@ var effectsCmd = &cobra.Command{
 			effects, err := transform.TransformEffect(transformInput.Transaction, LedgerSeq, transformInput.LedgerCloseMeta, env.NetworkPassphrase)
 			if err != nil {
 				txIndex := transformInput.Transaction.Index
-				cmdLogger.Errorf("could not transform transaction %d in ledger %d: %v", txIndex, LedgerSeq, err)
+				cmdLogger.LogError(fmt.Errorf("could not transform transaction %d in ledger %d: %v", txIndex, LedgerSeq, err))
 				numFailures += 1
 				continue
 			}

--- a/cmd/export_ledger_entry_changes.go
+++ b/cmd/export_ledger_entry_changes.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/ingest/ledgerbackend"
 	"github.com/stellar/go/xdr"
@@ -28,6 +29,7 @@ confirmed by the Stellar network.
 If no data type flags are set, then by default all of them are exported. If any are set, it is assumed that the others should not
 be exported.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		cmdLogger.SetLevel(logrus.InfoLevel)
 		commonArgs := utils.MustCommonFlags(cmd.Flags(), cmdLogger)
 		cmdLogger.StrictExport = commonArgs.StrictExport
 		env := utils.GetEnvironmentDetails(commonArgs)
@@ -316,7 +318,7 @@ func exportTransformedData(
 				case transform.ClaimableBalanceOutput:
 					// Skipping ClaimableBalanceOutputParquet because it is not needed in the current scope of work
 					// Note that ClaimableBalanceOutputParquet uses nested structs that will need to be handled
-					// for parquet conversio
+					// for parquet conversion
 					skip = true
 				case transform.ConfigSettingOutput:
 					transformedResource = append(transformedResource, v)

--- a/internal/input/changes.go
+++ b/internal/input/changes.go
@@ -128,7 +128,7 @@ func extractBatch(
 				if !ok {
 					// TODO: once LedgerEntryTypeData is tracked as well, all types should be addressed,
 					// so this info log should be a warning.
-					// Skip LedgerEntryTypeData as we are intentially not processing it
+					// Skip LedgerEntryTypeData as we are intentionally not processing it
 					if change.Type != xdr.LedgerEntryTypeData {
 						logger.Infof("change type: %v not tracked", change.Type)
 					}

--- a/internal/input/changes.go
+++ b/internal/input/changes.go
@@ -128,7 +128,10 @@ func extractBatch(
 				if !ok {
 					// TODO: once LedgerEntryTypeData is tracked as well, all types should be addressed,
 					// so this info log should be a warning.
-					logger.Infof("change type: %v not tracked", change.Type)
+					// Skip LedgerEntryTypeData as we are intentially not processing it
+					if change.Type != xdr.LedgerEntryTypeData {
+						logger.Infof("change type: %v not tracked", change.Type)
+					}
 				} else {
 					cache.AddChange(change)
 				}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository. I updated the description of the fuction with the changes that were made.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/_ , feature/_ or patch/\* .
</details>

### What

Updated some of the cmdLogger message types to error out properly when running stellar-etl in airflow.

`cmdLogger.Error/Errorf` does not actually return a status as failure from airflow's perspective. So these "errors" don't mark an airflow task as a failure. Only when an `Error` is coupled with `cmdLogger.LogError` or `cmdLogger.Fatal/Fatalf` will the airflow task be marked as failed.

### Why

Fix the logging issues when running stellar-etl in airflow.

### Known limitations

N/A
