### PR TITLE
Use xdr2json for invoke host parameters and constructor args

### DIFF
--- a/internal/transform/effects_test.go
+++ b/internal/transform/effects_test.go
@@ -2568,6 +2568,7 @@ func TestLiquidityPoolEffects(t *testing.T) {
 	source := xdr.MustMuxedAddress("GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY")
 	usdAsset := xdr.MustNewCreditAsset("USD", "GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY")
 	poolIDStr := "ea4e3e63a95fd840c1394f195722ffdcb2d0d4f0a26589c6ab557d81e6b0bf9d"
+	poolIDStrkey := "LDVE4PTDVFP5QQGBHFHRSVZC77OLFUGU6CRGLCOGVNKX3APGWC7Z3NUW"
 	var poolID xdr.PoolId
 	poolIDBytes, err := hex.DecodeString(poolIDStr)
 	assert.NoError(t, err)
@@ -2675,9 +2676,10 @@ func TestLiquidityPoolEffects(t *testing.T) {
 					Address:     "GAUJETIZVEP2NRYLUESJ3LS66NVCEGMON4UDCBCSBEVPIID773P2W6AY",
 					OperationID: 4294967297,
 					Details: map[string]interface{}{
-						"asset_type":        "liquidity_pool_shares",
-						"limit":             "0.0001000",
-						"liquidity_pool_id": poolIDStr,
+						"asset_type":               "liquidity_pool_shares",
+						"limit":                    "0.0001000",
+						"liquidity_pool_id":        poolIDStr,
+						"liquidity_pool_id_strkey": poolIDStrkey,
 					},
 					LedgerClosed:   genericCloseTime.UTC(),
 					LedgerSequence: 1,

--- a/internal/transform/operation.go
+++ b/internal/transform/operation.go
@@ -397,6 +397,12 @@ func addLiquidityPoolAssetDetails(result map[string]interface{}, lpp xdr.Liquidi
 		return err
 	}
 	result["liquidity_pool_id"] = PoolIDToString(poolID)
+	var poolIDStrkey string
+	poolIDStrkey, err = strkey.Encode(strkey.VersionByteLiquidityPool, poolID[:])
+	if err != nil {
+		return err
+	}
+	result["liquidity_pool_id_strkey"] = poolIDStrkey
 	return nil
 }
 
@@ -469,6 +475,7 @@ func addLedgerKeyToDetails(result map[string]interface{}, ledgerKey xdr.LedgerKe
 			return errors.Wrapf(err, "in claimable balance")
 		}
 		result["claimable_balance_id"] = marshalHex
+		result["claimable_balance_id_strkey"] = ledgerKey.ClaimableBalance.BalanceId.MustEncodeToStrkey()
 	case xdr.LedgerEntryTypeData:
 		result["data_account_id"] = ledgerKey.Data.AccountId.Address()
 		result["data_name"] = string(ledgerKey.Data.DataName)
@@ -477,12 +484,27 @@ func addLedgerKeyToDetails(result map[string]interface{}, ledgerKey xdr.LedgerKe
 	case xdr.LedgerEntryTypeTrustline:
 		result["trustline_account_id"] = ledgerKey.TrustLine.AccountId.Address()
 		if ledgerKey.TrustLine.Asset.Type == xdr.AssetTypeAssetTypePoolShare {
-			result["trustline_liquidity_pool_id"] = PoolIDToString(*ledgerKey.TrustLine.Asset.LiquidityPoolId)
+			var err error
+			var poolIDStrkey string
+			poolID := *ledgerKey.TrustLine.Asset.LiquidityPoolId
+			result["trustline_liquidity_pool_id"] = PoolIDToString(poolID)
+			poolIDStrkey, err = strkey.Encode(strkey.VersionByteLiquidityPool, poolID[:])
+			if err != nil {
+				return err
+			}
+			result["trustline_liquidity_pool_id_strkey"] = poolIDStrkey
 		} else {
 			result["trustline_asset"] = ledgerKey.TrustLine.Asset.ToAsset().StringCanonical()
 		}
 	case xdr.LedgerEntryTypeLiquidityPool:
+		var err error
+		var poolIDStrkey string
 		result["liquidity_pool_id"] = PoolIDToString(ledgerKey.LiquidityPool.LiquidityPoolId)
+		poolIDStrkey, err = strkey.Encode(strkey.VersionByteLiquidityPool, ledgerKey.LiquidityPool.LiquidityPoolId[:])
+		if err != nil {
+			return err
+		}
+		result["liquidity_pool_id_strkey"] = poolIDStrkey
 	}
 	return nil
 }
@@ -869,6 +891,7 @@ func extractOperationDetails(operation xdr.Operation, transaction ingest.LedgerT
 			return details, fmt.Errorf("invalid balanceId in op: %d", operationIndex)
 		}
 		details["balance_id"] = balanceID
+		details["balance_id_strkey"] = op.BalanceId.MustEncodeToStrkey()
 		if err := addAccountAndMuxedAccountDetails(details, sourceAccount, "claimant"); err != nil {
 			return details, err
 		}
@@ -915,6 +938,7 @@ func extractOperationDetails(operation xdr.Operation, transaction ingest.LedgerT
 			return details, fmt.Errorf("invalid balanceId in op: %d", operationIndex)
 		}
 		details["balance_id"] = balanceID
+		details["balance_id_strkey"] = op.BalanceId.MustEncodeToStrkey()
 
 	case xdr.OperationTypeSetTrustLineFlags:
 		op := operation.Body.MustSetTrustLineFlagsOp()
@@ -932,12 +956,21 @@ func extractOperationDetails(operation xdr.Operation, transaction ingest.LedgerT
 
 	case xdr.OperationTypeLiquidityPoolDeposit:
 		op := operation.Body.MustLiquidityPoolDepositOp()
-		details["liquidity_pool_id"] = PoolIDToString(op.LiquidityPoolId)
+		var err error
+		var poolIDStrkey string
 		var (
 			assetA, assetB         xdr.Asset
 			depositedA, depositedB xdr.Int64
 			sharesReceived         xdr.Int64
 		)
+
+		details["liquidity_pool_id"] = PoolIDToString(op.LiquidityPoolId)
+		poolIDStrkey, err = strkey.Encode(strkey.VersionByteLiquidityPool, op.LiquidityPoolId[:])
+		if err != nil {
+			return details, err
+		}
+		details["liquidity_pool_id_strkey"] = poolIDStrkey
+
 		if transaction.Result.Successful() {
 			// we will use the defaults (omitted asset and 0 amounts) if the transaction failed
 			lp, delta, err := getLiquidityPoolAndProductDelta(operationIndex, transaction, &op.LiquidityPoolId)
@@ -987,11 +1020,20 @@ func extractOperationDetails(operation xdr.Operation, transaction ingest.LedgerT
 
 	case xdr.OperationTypeLiquidityPoolWithdraw:
 		op := operation.Body.MustLiquidityPoolWithdrawOp()
-		details["liquidity_pool_id"] = PoolIDToString(op.LiquidityPoolId)
+		var err error
+		var poolIDStrkey string
 		var (
 			assetA, assetB       xdr.Asset
 			receivedA, receivedB xdr.Int64
 		)
+
+		details["liquidity_pool_id"] = PoolIDToString(op.LiquidityPoolId)
+		poolIDStrkey, err = strkey.Encode(strkey.VersionByteLiquidityPool, op.LiquidityPoolId[:])
+		if err != nil {
+			return details, err
+		}
+		details["liquidity_pool_id_strkey"] = poolIDStrkey
+
 		if transaction.Result.Successful() {
 			// we will use the defaults (omitted asset and 0 amounts) if the transaction failed
 			lp, delta, err := getLiquidityPoolAndProductDelta(operationIndex, transaction, &op.LiquidityPoolId)
@@ -1512,6 +1554,7 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 			panic(fmt.Errorf("invalid balanceId in op: %d", operation.index))
 		}
 		details["balance_id"] = balanceID
+		details["balance_id_strkey"] = op.BalanceId.MustEncodeToStrkey()
 		addAccountAndMuxedAccountDetails(details, *source, "claimant")
 	case xdr.OperationTypeBeginSponsoringFutureReserves:
 		op := operation.operation.Body.MustBeginSponsoringFutureReservesOp()
@@ -1545,6 +1588,7 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 			panic(fmt.Errorf("invalid balanceId in op: %d", operation.index))
 		}
 		details["balance_id"] = balanceID
+		details["balance_id_strkey"] = op.BalanceId.MustEncodeToStrkey()
 	case xdr.OperationTypeSetTrustLineFlags:
 		op := operation.operation.Body.MustSetTrustLineFlagsOp()
 		details["trustor"] = op.Trustor.Address()
@@ -1558,12 +1602,21 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 		}
 	case xdr.OperationTypeLiquidityPoolDeposit:
 		op := operation.operation.Body.MustLiquidityPoolDepositOp()
-		details["liquidity_pool_id"] = PoolIDToString(op.LiquidityPoolId)
+		var err error
+		var poolIDStrkey string
 		var (
 			assetA, assetB         string
 			depositedA, depositedB xdr.Int64
 			sharesReceived         xdr.Int64
 		)
+
+		details["liquidity_pool_id"] = PoolIDToString(op.LiquidityPoolId)
+		poolIDStrkey, err = strkey.Encode(strkey.VersionByteLiquidityPool, op.LiquidityPoolId[:])
+		if err != nil {
+			return details, err
+		}
+		details["liquidity_pool_id_strkey"] = poolIDStrkey
+
 		if operation.transaction.Result.Successful() {
 			// we will use the defaults (omitted asset and 0 amounts) if the transaction failed
 			lp, delta, err := operation.getLiquidityPoolAndProductDelta(&op.LiquidityPoolId)
@@ -1596,11 +1649,20 @@ func (operation *transactionOperationWrapper) Details() (map[string]interface{},
 		details["shares_received"] = amount.String(sharesReceived)
 	case xdr.OperationTypeLiquidityPoolWithdraw:
 		op := operation.operation.Body.MustLiquidityPoolWithdrawOp()
-		details["liquidity_pool_id"] = PoolIDToString(op.LiquidityPoolId)
+		var err error
+		var poolIDStrkey string
 		var (
 			assetA, assetB       string
 			receivedA, receivedB xdr.Int64
 		)
+
+		details["liquidity_pool_id"] = PoolIDToString(op.LiquidityPoolId)
+		poolIDStrkey, err = strkey.Encode(strkey.VersionByteLiquidityPool, op.LiquidityPoolId[:])
+		if err != nil {
+			return details, err
+		}
+		details["liquidity_pool_id_strkey"] = poolIDStrkey
+
 		if operation.transaction.Result.Successful() {
 			// we will use the defaults (omitted asset and 0 amounts) if the transaction failed
 			lp, delta, err := operation.getLiquidityPoolAndProductDelta(&op.LiquidityPoolId)
@@ -2025,6 +2087,7 @@ func addLedgerKeyDetails(result map[string]interface{}, ledgerKey xdr.LedgerKey)
 			return errors.Wrapf(err, "in claimable balance")
 		}
 		result["claimable_balance_id"] = marshalHex
+		result["claimable_balance_id_strkey"] = ledgerKey.ClaimableBalance.BalanceId.MustEncodeToStrkey()
 	case xdr.LedgerEntryTypeData:
 		result["data_account_id"] = ledgerKey.Data.AccountId.Address()
 		result["data_name"] = ledgerKey.Data.DataName
@@ -2033,12 +2096,29 @@ func addLedgerKeyDetails(result map[string]interface{}, ledgerKey xdr.LedgerKey)
 	case xdr.LedgerEntryTypeTrustline:
 		result["trustline_account_id"] = ledgerKey.TrustLine.AccountId.Address()
 		if ledgerKey.TrustLine.Asset.Type == xdr.AssetTypeAssetTypePoolShare {
-			result["trustline_liquidity_pool_id"] = PoolIDToString(*ledgerKey.TrustLine.Asset.LiquidityPoolId)
+			var err error
+			var poolIDStrkey string
+
+			poolID := *ledgerKey.TrustLine.Asset.LiquidityPoolId
+			result["trustline_liquidity_pool_id"] = PoolIDToString(poolID)
+			poolIDStrkey, err = strkey.Encode(strkey.VersionByteLiquidityPool, poolID[:])
+			if err != nil {
+				return err
+			}
+			result["trustline_liquidity_pool_id_strkey"] = poolIDStrkey
 		} else {
 			result["trustline_asset"] = ledgerKey.TrustLine.Asset.ToAsset().StringCanonical()
 		}
 	case xdr.LedgerEntryTypeLiquidityPool:
+		var err error
+		var poolIDStrkey string
+
 		result["liquidity_pool_id"] = PoolIDToString(ledgerKey.LiquidityPool.LiquidityPoolId)
+		poolIDStrkey, err = strkey.Encode(strkey.VersionByteLiquidityPool, ledgerKey.LiquidityPool.LiquidityPoolId[:])
+		if err != nil {
+			return err
+		}
+		result["liquidity_pool_id_strkey"] = poolIDStrkey
 	}
 	return nil
 }

--- a/internal/transform/operation_test.go
+++ b/internal/transform/operation_test.go
@@ -1844,11 +1844,31 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 				"contract_code_hash":    "",
 				"asset_balance_changes": []map[string]interface{}{},
 				"ledger_key_hash":       nilStringArray,
-				"parameters": []interface{}{
+				"parameters": []map[string]string{
+					{
+						"type":  "Address",
+						"value": "AAAAEgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+					},
+					{
+						"type":  "Sym",
+						"value": "AAAADwAAAAR0ZXN0",
+					},
+				},
+				"parameters_decoded": []map[string]string{
+					{
+						"type":  "Address",
+						"value": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+					},
+					{
+						"type":  "Sym",
+						"value": "test",
+					},
+				},
+				"parameters_json": []interface{}{
 					"AAAAEgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
 					"AAAADwAAAAR0ZXN0",
 				},
-				"parameters_decoded": []interface{}{
+				"parameters_json_decoded": []interface{}{
 					json.RawMessage(
 						"{\"address\":\"CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4\"}",
 					),
@@ -1867,11 +1887,31 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 				"contract_code_hash":    "",
 				"asset_balance_changes": []map[string]interface{}{},
 				"ledger_key_hash":       nilStringArray,
-				"parameters": []interface{}{
+				"parameters": []map[string]string{
+					{
+						"type":  "Address",
+						"value": "AAAAEgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+					},
+					{
+						"type":  "Sym",
+						"value": "AAAADwAAAAR0ZXN0",
+					},
+				},
+				"parameters_decoded": []map[string]string{
+					{
+						"type":  "Address",
+						"value": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+					},
+					{
+						"type":  "Sym",
+						"value": "test",
+					},
+				},
+				"parameters_json": []interface{}{
 					"AAAAEgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
 					"AAAADwAAAAR0ZXN0",
 				},
-				"parameters_decoded": []interface{}{
+				"parameters_json_decoded": []interface{}{
 					json.RawMessage(
 						"{\"address\":\"CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4\"}",
 					),
@@ -1951,10 +1991,22 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 				"from":               "asset",
 				"asset":              ":GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
 				"ledger_key_hash":    nilStringArray,
-				"parameters": []interface{}{
+				"parameters": []map[string]string{
+					{
+						"type":  "B",
+						"value": "AAAAAAAAAAE=",
+					},
+				},
+				"parameters_decoded": []map[string]string{
+					{
+						"type":  "B",
+						"value": "true",
+					},
+				},
+				"parameters_json": []interface{}{
 					"AAAAAAAAAAE=",
 				},
-				"parameters_decoded": []interface{}{json.RawMessage("{\"bool\":true}")},
+				"parameters_json_decoded": []interface{}{json.RawMessage("{\"bool\":true}")},
 			},
 			OperationResultCode: "OperationResultCodeOpInner",
 			OperationTraceCode:  "InvokeHostFunctionResultCodeInvokeHostFunctionSuccess",
@@ -1967,10 +2019,22 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 				"from":               "asset",
 				"asset":              ":GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
 				"ledger_key_hash":    nilStringArray,
-				"parameters": []interface{}{
+				"parameters": []map[string]string{
+					{
+						"type":  "B",
+						"value": "AAAAAAAAAAE=",
+					},
+				},
+				"parameters_decoded": []map[string]string{
+					{
+						"type":  "B",
+						"value": "true",
+					},
+				},
+				"parameters_json": []interface{}{
 					"AAAAAAAAAAE=",
 				},
-				"parameters_decoded": []interface{}{json.RawMessage("{\"bool\":true}")},
+				"parameters_json_decoded": []interface{}{json.RawMessage("{\"bool\":true}")},
 			},
 		},
 		OperationOutput{

--- a/internal/transform/operation_test.go
+++ b/internal/transform/operation_test.go
@@ -2,6 +2,7 @@ package transform
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -1843,25 +1844,17 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 				"contract_code_hash":    "",
 				"asset_balance_changes": []map[string]interface{}{},
 				"ledger_key_hash":       nilStringArray,
-				"parameters": []map[string]string{
-					{
-						"type":  "Address",
-						"value": "AAAAEgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-					},
-					{
-						"type":  "Sym",
-						"value": "AAAADwAAAAR0ZXN0",
-					},
+				"parameters": []interface{}{
+					"AAAAEgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+					"AAAADwAAAAR0ZXN0",
 				},
-				"parameters_decoded": []map[string]string{
-					{
-						"type":  "Address",
-						"value": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
-					},
-					{
-						"type":  "Sym",
-						"value": "test",
-					},
+				"parameters_decoded": []interface{}{
+					json.RawMessage(
+						"{\"address\":\"CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4\"}",
+					),
+					json.RawMessage(
+						"{\"symbol\":\"test\"}",
+					),
 				},
 			},
 			OperationResultCode: "OperationResultCodeOpInner",
@@ -1874,25 +1867,17 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 				"contract_code_hash":    "",
 				"asset_balance_changes": []map[string]interface{}{},
 				"ledger_key_hash":       nilStringArray,
-				"parameters": []map[string]string{
-					{
-						"type":  "Address",
-						"value": "AAAAEgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
-					},
-					{
-						"type":  "Sym",
-						"value": "AAAADwAAAAR0ZXN0",
-					},
+				"parameters": []interface{}{
+					"AAAAEgAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+					"AAAADwAAAAR0ZXN0",
 				},
-				"parameters_decoded": []map[string]string{
-					{
-						"type":  "Address",
-						"value": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
-					},
-					{
-						"type":  "Sym",
-						"value": "test",
-					},
+				"parameters_decoded": []interface{}{
+					json.RawMessage(
+						"{\"address\":\"CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4\"}",
+					),
+					json.RawMessage(
+						"{\"symbol\":\"test\"}",
+					),
 				},
 			},
 		},
@@ -1966,18 +1951,10 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 				"from":               "asset",
 				"asset":              ":GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
 				"ledger_key_hash":    nilStringArray,
-				"parameters": []map[string]string{
-					{
-						"type":  "B",
-						"value": "AAAAAAAAAAE=",
-					},
+				"parameters": []interface{}{
+					"AAAAAAAAAAE=",
 				},
-				"parameters_decoded": []map[string]string{
-					{
-						"type":  "B",
-						"value": "true",
-					},
-				},
+				"parameters_decoded": []interface{}{json.RawMessage("{\"bool\":true}")},
 			},
 			OperationResultCode: "OperationResultCodeOpInner",
 			OperationTraceCode:  "InvokeHostFunctionResultCodeInvokeHostFunctionSuccess",
@@ -1990,18 +1967,10 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 				"from":               "asset",
 				"asset":              ":GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
 				"ledger_key_hash":    nilStringArray,
-				"parameters": []map[string]string{
-					{
-						"type":  "B",
-						"value": "AAAAAAAAAAE=",
-					},
+				"parameters": []interface{}{
+					"AAAAAAAAAAE=",
 				},
-				"parameters_decoded": []map[string]string{
-					{
-						"type":  "B",
-						"value": "true",
-					},
-				},
+				"parameters_decoded": []interface{}{json.RawMessage("{\"bool\":true}")},
 			},
 		},
 		OperationOutput{

--- a/internal/transform/operation_test.go
+++ b/internal/transform/operation_test.go
@@ -1285,20 +1285,22 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			TransactionID: 4096,
 			OperationID:   4105,
 			OperationDetails: map[string]interface{}{
-				"trustor":           hardCodedSourceAccountAddress,
-				"limit":             50000000000.0,
-				"asset_type":        "liquidity_pool_shares",
-				"liquidity_pool_id": "185a6b384c651552ba09b32851b79f5f6ab61e80883d303f52bea1406a4923f0",
+				"trustor":                  hardCodedSourceAccountAddress,
+				"limit":                    50000000000.0,
+				"asset_type":               "liquidity_pool_shares",
+				"liquidity_pool_id":        "185a6b384c651552ba09b32851b79f5f6ab61e80883d303f52bea1406a4923f0",
+				"liquidity_pool_id_strkey": "LAMFU2ZYJRSRKUV2BGZSQUNXT5PWVNQ6QCED2MB7KK7KCQDKJER7BGLT",
 			},
 			ClosedAt:            hardCodedLedgerClose,
 			OperationResultCode: "OperationResultCodeOpInner",
 			OperationTraceCode:  "ChangeTrustResultCodeChangeTrustSuccess",
 			LedgerSequence:      0,
 			OperationDetailsJSON: map[string]interface{}{
-				"trustor":           hardCodedSourceAccountAddress,
-				"limit":             50000000000.0,
-				"asset_type":        "liquidity_pool_shares",
-				"liquidity_pool_id": "185a6b384c651552ba09b32851b79f5f6ab61e80883d303f52bea1406a4923f0",
+				"trustor":                  hardCodedSourceAccountAddress,
+				"limit":                    50000000000.0,
+				"asset_type":               "liquidity_pool_shares",
+				"liquidity_pool_id":        "185a6b384c651552ba09b32851b79f5f6ab61e80883d303f52bea1406a4923f0",
+				"liquidity_pool_id_strkey": "LAMFU2ZYJRSRKUV2BGZSQUNXT5PWVNQ6QCED2MB7KK7KCQDKJER7BGLT",
 			},
 		},
 		{
@@ -1502,16 +1504,18 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			TransactionID: 4096,
 			OperationID:   4114,
 			OperationDetails: map[string]interface{}{
-				"claimant":   hardCodedSourceAccountAddress,
-				"balance_id": "000000000102030405060708090000000000000000000000000000000000000000000000",
+				"claimant":          hardCodedSourceAccountAddress,
+				"balance_id":        "000000000102030405060708090000000000000000000000000000000000000000000000",
+				"balance_id_strkey": "BAAACAQDAQCQMBYIBEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACPGI",
 			},
 			ClosedAt:            hardCodedLedgerClose,
 			OperationResultCode: "OperationResultCodeOpInner",
 			OperationTraceCode:  "ClaimClaimableBalanceResultCodeClaimClaimableBalanceSuccess",
 			LedgerSequence:      0,
 			OperationDetailsJSON: map[string]interface{}{
-				"claimant":   hardCodedSourceAccountAddress,
-				"balance_id": "000000000102030405060708090000000000000000000000000000000000000000000000",
+				"claimant":          hardCodedSourceAccountAddress,
+				"balance_id":        "000000000102030405060708090000000000000000000000000000000000000000000000",
+				"balance_id_strkey": "BAAACAQDAQCQMBYIBEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACPGI",
 			},
 		},
 		{
@@ -1574,14 +1578,16 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			TransactionID: 4096,
 			OperationID:   4118,
 			OperationDetails: map[string]interface{}{
-				"claimable_balance_id": "000000000102030405060708090000000000000000000000000000000000000000000000",
+				"claimable_balance_id":        "000000000102030405060708090000000000000000000000000000000000000000000000",
+				"claimable_balance_id_strkey": "BAAACAQDAQCQMBYIBEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACPGI",
 			},
 			ClosedAt:            hardCodedLedgerClose,
 			OperationResultCode: "OperationResultCodeOpInner",
 			OperationTraceCode:  "RevokeSponsorshipResultCodeRevokeSponsorshipSuccess",
 			LedgerSequence:      0,
 			OperationDetailsJSON: map[string]interface{}{
-				"claimable_balance_id": "000000000102030405060708090000000000000000000000000000000000000000000000",
+				"claimable_balance_id":        "000000000102030405060708090000000000000000000000000000000000000000000000",
+				"claimable_balance_id_strkey": "BAAACAQDAQCQMBYIBEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACPGI",
 			},
 		},
 		{
@@ -1646,14 +1652,16 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			TransactionID: 4096,
 			OperationID:   4122,
 			OperationDetails: map[string]interface{}{
-				"liquidity_pool_id": "0102030405060708090000000000000000000000000000000000000000000000",
+				"liquidity_pool_id":        "0102030405060708090000000000000000000000000000000000000000000000",
+				"liquidity_pool_id_strkey": "LAAQEAYEAUDAOCAJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATUC",
 			},
 			ClosedAt:            hardCodedLedgerClose,
 			OperationResultCode: "OperationResultCodeOpInner",
 			OperationTraceCode:  "RevokeSponsorshipResultCodeRevokeSponsorshipSuccess",
 			LedgerSequence:      0,
 			OperationDetailsJSON: map[string]interface{}{
-				"liquidity_pool_id": "0102030405060708090000000000000000000000000000000000000000000000",
+				"liquidity_pool_id":        "0102030405060708090000000000000000000000000000000000000000000000",
+				"liquidity_pool_id_strkey": "LAAQEAYEAUDAOCAJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATUC",
 			},
 		},
 		{
@@ -1690,14 +1698,16 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			TransactionID: 4096,
 			OperationID:   4124,
 			OperationDetails: map[string]interface{}{
-				"balance_id": "000000000102030405060708090000000000000000000000000000000000000000000000",
+				"balance_id":        "000000000102030405060708090000000000000000000000000000000000000000000000",
+				"balance_id_strkey": "BAAACAQDAQCQMBYIBEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACPGI",
 			},
 			ClosedAt:            hardCodedLedgerClose,
 			OperationResultCode: "OperationResultCodeOpInner",
 			OperationTraceCode:  "ClawbackClaimableBalanceResultCodeClawbackClaimableBalanceSuccess",
 			LedgerSequence:      0,
 			OperationDetailsJSON: map[string]interface{}{
-				"balance_id": "000000000102030405060708090000000000000000000000000000000000000000000000",
+				"balance_id":        "000000000102030405060708090000000000000000000000000000000000000000000000",
+				"balance_id_strkey": "BAAACAQDAQCQMBYIBEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACPGI",
 			},
 		},
 		{
@@ -1741,6 +1751,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			OperationID:   4126,
 			OperationDetails: map[string]interface{}{
 				"liquidity_pool_id":        "0102030405060708090000000000000000000000000000000000000000000000",
+				"liquidity_pool_id_strkey": "LAAQEAYEAUDAOCAJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATUC",
 				"reserve_a_asset_type":     "native",
 				"reserve_a_asset_id":       int64(-5706705804583548011),
 				"reserve_a_max_amount":     0.0001,
@@ -1769,6 +1780,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			LedgerSequence:      0,
 			OperationDetailsJSON: map[string]interface{}{
 				"liquidity_pool_id":        "0102030405060708090000000000000000000000000000000000000000000000",
+				"liquidity_pool_id_strkey": "LAAQEAYEAUDAOCAJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATUC",
 				"reserve_a_asset_type":     "native",
 				"reserve_a_asset_id":       int64(-5706705804583548011),
 				"reserve_a_max_amount":     0.0001,
@@ -1800,6 +1812,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			OperationID:   4127,
 			OperationDetails: map[string]interface{}{
 				"liquidity_pool_id":         "0102030405060708090000000000000000000000000000000000000000000000",
+				"liquidity_pool_id_strkey":  "LAAQEAYEAUDAOCAJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATUC",
 				"reserve_a_asset_type":      "native",
 				"reserve_a_asset_id":        int64(-5706705804583548011),
 				"reserve_a_min_amount":      0.0000001,
@@ -1818,6 +1831,7 @@ func makeOperationTestOutputs() (transformedOperations []OperationOutput) {
 			LedgerSequence:      0,
 			OperationDetailsJSON: map[string]interface{}{
 				"liquidity_pool_id":         "0102030405060708090000000000000000000000000000000000000000000000",
+				"liquidity_pool_id_strkey":  "LAAQEAYEAUDAOCAJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATUC",
 				"reserve_a_asset_type":      "native",
 				"reserve_a_asset_id":        int64(-5706705804583548011),
 				"reserve_a_min_amount":      0.0000001,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository. I updated the description of the fuction with the changes that were made.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to major/_ , minor/_ or patch/\* .
</details>

### What

https://github.com/stellar/stellar-etl/issues/330

InvokeHostFunction should use xdr2json on the ScVal parameters and constructor args

### Why

This is to use the same formatting and decomposition of ScVals as contract_events/data uses instead of the looping logic to parse the ScVal into the details map

### Known limitations

* Need to backfill all smart contract operations from Feb 2024 to current
