### PR TITLE
Pin GitHub Actions to specific commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           ETLHASH: stellar/stellar-etl-dev:${SHORT_SHA}
 
       - name: Login to DockerHub
-        uses: docker/login-action@bb984efc561711aaa26e433c32c3521176eae55b
+        uses: docker/login-action@bb984efc561711aaa26e433c32c3521176eae55b # v1.14.0
         with:
           username: stellardataeng
           password: ${{ secrets.DOCKER_CREDS_DEV }}

--- a/.github/workflows/lint-tests.yml
+++ b/.github/workflows/lint-tests.yml
@@ -27,10 +27,10 @@ jobs:
           go-version: 1
 
       - id: file_changes
-        uses: trilom/file-changes-action@v1.2.4
+        uses: trilom/file-changes-action@a6ca26c14274c33b15e6499323aac178af06ad4b # v1.2.4
         with:
           output: " "
 
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # v3.0.0
         env:
           extra_args: --color=always --files ${{ steps.file_changes.outputs.files}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           git tag ${{ steps.nextversion.outputs.NEXT_VERSION }}
           git push origin ${{ steps.nextversion.outputs.NEXT_VERSION }}
 
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5.25.0
         with:
           commitish: master
           name: "stellar-etl ${{ steps.nextversion.outputs.NEXT_VERSION }}"


### PR DESCRIPTION
### What
  Pin GitHub Actions third party dependencies to specific commits in workflow files.

  ### Why
  It is a security best practice. When using a branch or tag reference instead of a commit, the dependency is in control of what code will execute in GitHub Actions, potentially exposed to secrets or escalated access, because the author of the dependency may change the code the branch or tag references at anytime.

See https://docs.github.com/en/actions/reference/secure-use-reference#using-third-party-actions.