### PR TITLE
Bump docker version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN go build -v -o /usr/local/bin ./...
 
 
 # stage 2: runtime enviroment
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get update && apt-get install -y ca-certificates
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository. I updated the description of the fuction with the changes that were made.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to major/_ , minor/_ or patch/\* .
</details>

### What

stellar-etl within the docker image isn't running. Need to bump the version to make it work

### Why

We get this error otherwise
```
[2025-11-07, 20:31:50 UTC] {pod_manager.py:496} INFO - [base] stellar-etl: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by stellar-etl)
```

### Known limitations

[TODO or N/A]
