### PR TITLE
Add TimestampToLedger to export commands

### DIFF
--- a/cmd/export_contract_events.go
+++ b/cmd/export_contract_events.go
@@ -22,6 +22,18 @@ var contractEventsCmd = &cobra.Command{
 		commonArgs := utils.MustCommonFlags(cmd.Flags(), cmdLogger)
 		env := utils.GetEnvironmentDetails(commonArgs)
 
+		var err error
+
+		// If start/end timestamps are provided, override start/end ledger.
+		// TODO: StartTimestamp and EndTimestamp default to "" to fit with how our current parameters are parsed.
+		// We should refactor this later when we refactor our parameter parsing.
+		if cmdArgs.StartTimestamp != "" && cmdArgs.EndTimestamp != "" {
+			cmdArgs.StartNum, commonArgs.EndNum, err = TimestampToLedger(cmdArgs.StartTimestamp, cmdArgs.EndTimestamp, commonArgs.IsTest, commonArgs.IsFuture)
+			if err != nil {
+				cmdLogger.Fatal("could not calculate ledger range: ", err)
+			}
+		}
+
 		transactions, err := input.GetTransactions(cmdArgs.StartNum, cmdArgs.EndNum, cmdArgs.Limit, env, cmdArgs.UseCaptiveCore)
 		if err != nil {
 			cmdLogger.Fatal("could not read transactions: ", err)
@@ -74,6 +86,6 @@ func init() {
 	utils.AddArchiveFlags("contract_events", contractEventsCmd.Flags())
 	utils.AddCloudStorageFlags(contractEventsCmd.Flags())
 
-	contractEventsCmd.MarkFlagRequired("start-ledger")
-	contractEventsCmd.MarkFlagRequired("end-ledger")
+	//contractEventsCmd.MarkFlagRequired("start-ledger")
+	//contractEventsCmd.MarkFlagRequired("end-ledger")
 }

--- a/cmd/export_effects.go
+++ b/cmd/export_effects.go
@@ -18,9 +18,21 @@ var effectsCmd = &cobra.Command{
 		cmdLogger.SetLevel(logrus.InfoLevel)
 		commonArgs := utils.MustCommonFlags(cmd.Flags(), cmdLogger)
 		cmdLogger.StrictExport = commonArgs.StrictExport
-		startNum, path, parquetPath, limit := utils.MustArchiveFlags(cmd.Flags(), cmdLogger)
+		startNum, startTimestamp, path, parquetPath, limit := utils.MustArchiveFlags(cmd.Flags(), cmdLogger)
 		cloudStorageBucket, cloudCredentials, cloudProvider := utils.MustCloudStorageFlags(cmd.Flags(), cmdLogger)
 		env := utils.GetEnvironmentDetails(commonArgs)
+
+		var err error
+
+		// If start/end timestamps are provided, override start/end ledger.
+		// TODO: StartTimestamp and EndTimestamp default to "" to fit with how our current parameters are parsed.
+		// We should refactor this later when we refactor our parameter parsing.
+		if startTimestamp != "" && commonArgs.EndTimestamp != "" {
+			startNum, commonArgs.EndNum, err = TimestampToLedger(startTimestamp, commonArgs.EndTimestamp, commonArgs.IsTest, commonArgs.IsFuture)
+			if err != nil {
+				cmdLogger.Fatal("could not calculate ledger range: ", err)
+			}
+		}
 
 		transactions, err := input.GetTransactions(startNum, commonArgs.EndNum, limit, env, commonArgs.UseCaptiveCore)
 		if err != nil {
@@ -75,7 +87,7 @@ func init() {
 	utils.AddCommonFlags(effectsCmd.Flags())
 	utils.AddArchiveFlags("effects", effectsCmd.Flags())
 	utils.AddCloudStorageFlags(effectsCmd.Flags())
-	effectsCmd.MarkFlagRequired("end-ledger")
+	//effectsCmd.MarkFlagRequired("end-ledger")
 
 	/*
 		Current flags:

--- a/cmd/export_operations.go
+++ b/cmd/export_operations.go
@@ -18,9 +18,21 @@ var operationsCmd = &cobra.Command{
 		cmdLogger.SetLevel(logrus.InfoLevel)
 		commonArgs := utils.MustCommonFlags(cmd.Flags(), cmdLogger)
 		cmdLogger.StrictExport = commonArgs.StrictExport
-		startNum, path, parquetPath, limit := utils.MustArchiveFlags(cmd.Flags(), cmdLogger)
+		startNum, startTimestamp, path, parquetPath, limit := utils.MustArchiveFlags(cmd.Flags(), cmdLogger)
 		cloudStorageBucket, cloudCredentials, cloudProvider := utils.MustCloudStorageFlags(cmd.Flags(), cmdLogger)
 		env := utils.GetEnvironmentDetails(commonArgs)
+
+		var err error
+
+		// If start/end timestamps are provided, override start/end ledger.
+		// TODO: StartTimestamp and EndTimestamp default to "" to fit with how our current parameters are parsed.
+		// We should refactor this later when we refactor our parameter parsing.
+		if startTimestamp != "" && commonArgs.EndTimestamp != "" {
+			startNum, commonArgs.EndNum, err = TimestampToLedger(startTimestamp, commonArgs.EndTimestamp, commonArgs.IsTest, commonArgs.IsFuture)
+			if err != nil {
+				cmdLogger.Fatal("could not calculate ledger range: ", err)
+			}
+		}
 
 		operations, err := input.GetOperations(startNum, commonArgs.EndNum, limit, env, commonArgs.UseCaptiveCore)
 		if err != nil {
@@ -72,7 +84,7 @@ func init() {
 	utils.AddCommonFlags(operationsCmd.Flags())
 	utils.AddArchiveFlags("operations", operationsCmd.Flags())
 	utils.AddCloudStorageFlags(operationsCmd.Flags())
-	operationsCmd.MarkFlagRequired("end-ledger")
+	//operationsCmd.MarkFlagRequired("end-ledger")
 
 	/*
 		Current flags:

--- a/cmd/export_transactions.go
+++ b/cmd/export_transactions.go
@@ -18,9 +18,21 @@ var transactionsCmd = &cobra.Command{
 		cmdLogger.SetLevel(logrus.InfoLevel)
 		commonArgs := utils.MustCommonFlags(cmd.Flags(), cmdLogger)
 		cmdLogger.StrictExport = commonArgs.StrictExport
-		startNum, path, parquetPath, limit := utils.MustArchiveFlags(cmd.Flags(), cmdLogger)
+		startNum, startTimestamp, path, parquetPath, limit := utils.MustArchiveFlags(cmd.Flags(), cmdLogger)
 		cloudStorageBucket, cloudCredentials, cloudProvider := utils.MustCloudStorageFlags(cmd.Flags(), cmdLogger)
 		env := utils.GetEnvironmentDetails(commonArgs)
+
+		var err error
+
+		// If start/end timestamps are provided, override start/end ledger.
+		// TODO: StartTimestamp and EndTimestamp default to "" to fit with how our current parameters are parsed.
+		// We should refactor this later when we refactor our parameter parsing.
+		if startTimestamp != "" && commonArgs.EndTimestamp != "" {
+			startNum, commonArgs.EndNum, err = TimestampToLedger(startTimestamp, commonArgs.EndTimestamp, commonArgs.IsTest, commonArgs.IsFuture)
+			if err != nil {
+				cmdLogger.Fatal("could not calculate ledger range: ", err)
+			}
+		}
 
 		transactions, err := input.GetTransactions(startNum, commonArgs.EndNum, limit, env, commonArgs.UseCaptiveCore)
 		if err != nil {
@@ -72,7 +84,7 @@ func init() {
 	utils.AddCommonFlags(transactionsCmd.Flags())
 	utils.AddArchiveFlags("transactions", transactionsCmd.Flags())
 	utils.AddCloudStorageFlags(transactionsCmd.Flags())
-	transactionsCmd.MarkFlagRequired("end-ledger")
+	//transactionsCmd.MarkFlagRequired("end-ledger")
 
 	/*
 		Current flags:


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository. I updated the description of the fuction with the changes that were made.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to major/_ , minor/_ or patch/\* .
</details>

### What

Updated export commands to export from timestamp ranges instead of only from ledger sequence ranges

### Why

Part of the work to remove our dependency on XCOM in Airflow

### Known limitations

N/A
