### PR TITLE
Use GCS datastore backend for get_ledger_range_from_times

### DIFF
--- a/cmd/get_ledger_range_from_times.go
+++ b/cmd/get_ledger_range_from_times.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stellar/stellar-etl/v2/internal/input"
+	"github.com/stellar/stellar-etl/v2/internal/utils"
 
 	"github.com/spf13/cobra"
 )
@@ -49,6 +50,11 @@ var getLedgerRangeFromTimesCmd = &cobra.Command{
 			cmdLogger.Fatal("could not get futurenet boolean: ", err)
 		}
 
+		datastorePath, err := cmd.Flags().GetString("datastore-path")
+		if err != nil {
+			cmdLogger.Fatal("could not get datastore path: ", err)
+		}
+
 		formatString := "2006-01-02T15:04:05-07:00"
 		startTime, err := time.Parse(formatString, startString)
 		if err != nil {
@@ -60,7 +66,13 @@ var getLedgerRangeFromTimesCmd = &cobra.Command{
 			cmdLogger.Fatal("could not parse end time: ", err)
 		}
 
-		startLedger, endLedger, err := input.GetLedgerRange(startTime, endTime, isTest, isFuture)
+		env := utils.GetEnvironmentDetails(utils.CommonFlagValues{
+			IsTest:        isTest,
+			IsFuture:      isFuture,
+			DatastorePath: datastorePath,
+		})
+
+		startLedger, endLedger, err := input.GetLedgerRange(startTime, endTime, env)
 		if err != nil {
 			cmdLogger.Fatal("could not calculate ledger range: ", err)
 		}
@@ -90,6 +102,7 @@ func init() {
 	getLedgerRangeFromTimesCmd.Flags().StringP("output", "o", "exported_range.txt", "Filename of the output file")
 	getLedgerRangeFromTimesCmd.Flags().Bool("testnet", false, "If set, the batch job will connect to testnet instead of mainnet.")
 	getLedgerRangeFromTimesCmd.Flags().Bool("futurenet", false, "If set, the batch job will connect to futurenet instead of mainnet.")
+	getLedgerRangeFromTimesCmd.Flags().String("datastore-path", "sdf-ledger-close-meta/v1/ledgers", "GCS datastore path containing LedgerCloseMetaBatch files used for the binary search over close times.")
 
 	getLedgerRangeFromTimesCmd.MarkFlagRequired("start-time")
 	getLedgerRangeFromTimesCmd.MarkFlagRequired("end-time")

--- a/internal/input/ledger_range.go
+++ b/internal/input/ledger_range.go
@@ -1,229 +1,165 @@
 package input
 
 import (
+	"context"
 	"fmt"
 	"time"
 
+	"github.com/stellar/go-stellar-sdk/support/compressxdr"
+	"github.com/stellar/go-stellar-sdk/support/datastore"
+	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stellar/stellar-etl/v2/internal/utils"
-
-	"github.com/stellar/go-stellar-sdk/historyarchive"
 )
 
-// graphPoint represents a single point in the graph. It includes the ledger sequence and close time (in UTC)
-type graphPoint struct {
-	Seq       int64
-	CloseTime time.Time
-}
-
-/*
-The graph struct is used to calculate ledger ranges from time ranges. It keeps track of its boundaries, and uses its backend to
-retrieve new graphPoints as necessary. As the sequence number increases, so does the close time, so we can use the graph to find
-sequence numbers that correspond to a given close time fairly easily.
-*/
-type graph struct {
-	Client     historyarchive.ArchiveInterface
-	BeginPoint graphPoint
-	EndPoint   graphPoint
-}
-
-const avgCloseTime = time.Second * 5 // average time to close a stellar ledger
-
-// GetLedgerRange calculates the ledger range that spans the provided date range
-func GetLedgerRange(startTime, endTime time.Time, isTest bool, isFuture bool) (int64, int64, error) {
+// GetLedgerRange converts a time range to a ledger range by binary-searching the GCS datastore
+// configured on env.CommonFlagValues.DatastorePath. Each probe fetches a single
+// LedgerCloseMetaBatch file via the datastore's random-access API, so it does not rely on the
+// sequential BufferedStorageBackend path used by the bulk export commands.
+func GetLedgerRange(startTime, endTime time.Time, env utils.EnvironmentDetails) (int64, int64, error) {
 	startTime = startTime.UTC()
 	endTime = endTime.UTC()
-	commonFlagValues := utils.CommonFlagValues{
-		IsTest:   isTest,
-		IsFuture: isFuture,
-	}
-	env := utils.GetEnvironmentDetails(commonFlagValues)
-
 	if startTime.After(endTime) {
 		return 0, 0, fmt.Errorf("start time must be less than or equal to the end time")
 	}
 
-	graph, err := createNewGraph(env.ArchiveURLs)
+	ctx := context.Background()
+	ds, dsCfg, err := utils.CreateDatastore(ctx, env)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer ds.Close()
+
+	finder := &ledgerFinder{
+		ds:     ds,
+		schema: dsCfg.Schema,
+		cache:  map[uint32]ledgerPoint{},
+	}
+
+	oldestSeq, err := datastore.FindOldestLedgerSequence(ctx, ds, dsCfg.Schema)
+	if err != nil {
+		return 0, 0, fmt.Errorf("unable to find oldest ledger in datastore: %w", err)
+	}
+	latestSeq, err := datastore.FindLatestLedgerSequence(ctx, ds)
+	if err != nil {
+		return 0, 0, fmt.Errorf("unable to find latest ledger in datastore: %w", err)
+	}
+
+	oldestPt, err := finder.pointAt(ctx, oldestSeq)
+	if err != nil {
+		return 0, 0, err
+	}
+	latestPt, err := finder.pointAt(ctx, latestSeq)
 	if err != nil {
 		return 0, 0, err
 	}
 
-	err = graph.limitLedgerRange(&startTime, &endTime)
+	// Clamp requested times to the datastore's available range (same semantics as the
+	// history-archive-backed implementation's limitLedgerRange).
+	if startTime.Before(oldestPt.closeTime) {
+		startTime = oldestPt.closeTime
+	} else if startTime.After(latestPt.closeTime) {
+		startTime = latestPt.closeTime
+	}
+	if endTime.After(latestPt.closeTime) {
+		endTime = latestPt.closeTime
+	} else if endTime.Before(oldestPt.closeTime) {
+		endTime = oldestPt.closeTime
+	}
+
+	startLedger, err := finder.findLedgerForTime(ctx, startTime, oldestPt, latestPt)
+	if err != nil {
+		return 0, 0, err
+	}
+	endLedger, err := finder.findLedgerForTime(ctx, endTime, oldestPt, latestPt)
 	if err != nil {
 		return 0, 0, err
 	}
 
-	// Ledger sequence 2 is the start ledger because the genesis ledger (ledger 1), has a close time of 0 in Unix time.
-	// The second ledger has a valid close time that matches with the network start time.
-	startLedger, err := graph.findLedgerForDate(2, startTime, map[int64]struct{}{})
-	if err != nil {
-		return 0, 0, err
-	}
-
-	endLedger, err := graph.findLedgerForDate(2, endTime, map[int64]struct{}{})
-	if err != nil {
-		return 0, 0, err
-	}
-
-	return startLedger, endLedger, nil
+	return int64(startLedger), int64(endLedger), nil
 }
 
-// createNewGraph makes a new graph with the endpoints equal to the network's endpoints
-func createNewGraph(archiveURLs []string) (graph, error) {
-	graph := graph{}
-	archive, err := utils.CreateHistoryArchiveClient(archiveURLs)
-	if err != nil {
-		return graph, err
-	}
-
-	graph.Client = archive
-
-	secondLedgerPoint, err := graph.getGraphPoint(2) // the second ledger has a real close time, unlike the 1970s close time of the genesis ledger
-	if err != nil {
-		return graph, err
-	}
-
-	graph.BeginPoint = secondLedgerPoint
-
-	root, err := graph.Client.GetRootHAS()
-	if err != nil {
-		return graph, err
-	}
-
-	latestPoint, err := graph.getGraphPoint(int64(root.CurrentLedger))
-	if err != nil {
-		return graph, err
-	}
-
-	graph.EndPoint = latestPoint
-	return graph, nil
+type ledgerPoint struct {
+	seq       uint32
+	closeTime time.Time
 }
 
-func (g graph) findLedgerForTimeBinary(targetTime time.Time, start, end graphPoint) (int64, error) {
-	if end.Seq >= 2 {
-		middleLedger := start.Seq + (end.Seq-start.Seq)/2
-		middleTime, err := g.getGraphPoint(middleLedger)
-		if err != nil {
-			return 0, err
-		}
-
-		// check if middle element is the one to choose
-		if middleLedger > 1 {
-			prevLedger := middleLedger - 1
-			prevTime, err := g.getGraphPoint(prevLedger)
-			if err != nil {
-				return 0, err
-			}
-
-			if prevTime.CloseTime.Unix() < targetTime.Unix() && middleTime.CloseTime.Unix() >= targetTime.Unix() {
-				return middleLedger, nil
-			}
-		}
-
-		if middleTime.CloseTime.Unix() > targetTime.Unix() {
-			newEnd, err := g.getGraphPoint(middleLedger - 1)
-			if err != nil {
-				return 0, err
-			}
-
-			return g.findLedgerForTimeBinary(targetTime, start, newEnd)
-		}
-
-		newStart, err := g.getGraphPoint(middleLedger + 1)
-		if err != nil {
-			return 0, err
-		}
-
-		return g.findLedgerForTimeBinary(targetTime, newStart, end)
-	}
-
-	return 0, fmt.Errorf("unable to find ledger with close time %v: ", targetTime)
+type ledgerFinder struct {
+	ds     datastore.DataStore
+	schema datastore.DataStoreSchema
+	cache  map[uint32]ledgerPoint
 }
 
-// findLedgerForDate recursively searches for the ledger that was closed on or directly after targetTime
-func (g graph) findLedgerForDate(currentLedger int64, targetTime time.Time, seenLedgers map[int64]struct{}) (int64, error) {
-	seenLedgers[currentLedger] = struct{}{}
+// pointAt fetches the close time for a single ledger sequence by downloading its
+// LedgerCloseMetaBatch file from the datastore and decoding the contained LedgerCloseMeta.
+// Results are memoized to avoid duplicate GETs across the two binary searches and between
+// findLedgerForTime's neighbour probes.
+func (f *ledgerFinder) pointAt(ctx context.Context, seq uint32) (ledgerPoint, error) {
+	if pt, ok := f.cache[seq]; ok {
+		return pt, nil
+	}
+	key := f.schema.GetObjectKeyFromSequenceNumber(seq)
+	rc, err := f.ds.GetFile(ctx, key)
+	if err != nil {
+		return ledgerPoint{}, fmt.Errorf("unable to fetch ledger %d (%s) from datastore: %w", seq, key, err)
+	}
+	defer rc.Close()
 
-	currentPoint, err := g.getGraphPoint(currentLedger)
+	var batch xdr.LedgerCloseMetaBatch
+	dec := compressxdr.NewXDRDecoder(compressxdr.DefaultCompressor, &batch)
+	if _, err := dec.ReadFrom(rc); err != nil {
+		return ledgerPoint{}, fmt.Errorf("unable to decode batch for ledger %d: %w", seq, err)
+	}
+
+	lcm, err := batch.GetLedger(seq)
+	if err != nil {
+		return ledgerPoint{}, fmt.Errorf("batch does not contain ledger %d: %w", seq, err)
+	}
+	closeTime, err := utils.GetCloseTime(lcm)
+	if err != nil {
+		return ledgerPoint{}, fmt.Errorf("unable to extract close time for ledger %d: %w", seq, err)
+	}
+
+	pt := ledgerPoint{seq: seq, closeTime: closeTime}
+	f.cache[seq] = pt
+	return pt, nil
+}
+
+// findLedgerForTime returns the first ledger whose close time is >= target, assuming
+// start.seq <= end.seq and close times are monotonically non-decreasing. The boundary
+// predicate (prev.Unix() < target && curr.Unix() >= target) matches the existing
+// findLedgerForTimeBinary in the history-archive implementation, so golden outputs align.
+func (f *ledgerFinder) findLedgerForTime(ctx context.Context, target time.Time, start, end ledgerPoint) (uint32, error) {
+	if start.seq >= end.seq {
+		return start.seq, nil
+	}
+
+	mid := start.seq + (end.seq-start.seq)/2
+	midPt, err := f.pointAt(ctx, mid)
 	if err != nil {
 		return 0, err
 	}
 
-	if currentLedger > 1 {
-		prevLedger := currentLedger - 1
-		prevTime, err := g.getGraphPoint(prevLedger)
+	if mid > start.seq {
+		prevPt, err := f.pointAt(ctx, mid-1)
 		if err != nil {
 			return 0, err
 		}
-
-		if prevTime.CloseTime.Unix() < targetTime.Unix() && currentPoint.CloseTime.Unix() >= targetTime.Unix() {
-			return currentLedger, nil
+		if prevPt.closeTime.Unix() < target.Unix() && midPt.closeTime.Unix() >= target.Unix() {
+			return mid, nil
 		}
 	}
 
-	timeDiff := targetTime.Sub(currentPoint.CloseTime).Seconds()
-	ledgerOffset := int64(timeDiff / avgCloseTime.Seconds())
-	if ledgerOffset == 0 {
-		if timeDiff > 0 {
-			ledgerOffset = 1
-		} else {
-			ledgerOffset = -1
+	if midPt.closeTime.Unix() > target.Unix() {
+		newEnd, err := f.pointAt(ctx, mid-1)
+		if err != nil {
+			return 0, err
 		}
+		return f.findLedgerForTime(ctx, target, start, newEnd)
 	}
 
-	newLedger := currentLedger + ledgerOffset
-
-	if newLedger > g.EndPoint.Seq {
-		newLedger = g.EndPoint.Seq
-	} else if newLedger < g.BeginPoint.Seq {
-		// since we started with BeginPoint, returning to it would create an infinite cycle;
-		newLedger = g.BeginPoint.Seq + 1
-	}
-
-	// if we have already seen this ledger, it means the algorithm is trapped in a cycle; use binary search instead (slower but will find the ledger)
-	if _, exists := seenLedgers[newLedger]; exists {
-		// since we have already calculated the current point, we can use it as the upper or lower bound.
-		// This way, the binary search doesn't have to search the entire space
-		if ledgerOffset > 0 {
-			return g.findLedgerForTimeBinary(targetTime, currentPoint, g.EndPoint)
-		}
-
-		return g.findLedgerForTimeBinary(targetTime, g.BeginPoint, currentPoint)
-	}
-
-	return g.findLedgerForDate(newLedger, targetTime, seenLedgers)
-}
-
-// limitLedgerRange restricts start and end by setting them to be the edges of the network's range if they are outside that range
-func (g graph) limitLedgerRange(start, end *time.Time) error {
-	if start.Before(g.BeginPoint.CloseTime) {
-		*start = g.BeginPoint.CloseTime
-	} else if start.After(g.EndPoint.CloseTime) {
-		*start = g.EndPoint.CloseTime
-	}
-
-	if end.After(g.EndPoint.CloseTime) {
-		*end = g.EndPoint.CloseTime
-	} else if end.Before(g.BeginPoint.CloseTime) {
-		*end = g.BeginPoint.CloseTime
-	}
-
-	return nil
-}
-
-// getGraphPoint gets the graphPoint representation of the ledger with the provided sequence number
-func (g graph) getGraphPoint(sequence int64) (graphPoint, error) {
-	ledger, err := g.Client.GetLedgerHeader(uint32(sequence))
+	newStart, err := f.pointAt(ctx, mid+1)
 	if err != nil {
-		return graphPoint{}, fmt.Errorf(fmt.Sprintf("unable to get ledger %d: ", sequence), err)
+		return 0, err
 	}
-
-	closeTime, err := utils.ExtractLedgerCloseTime(ledger)
-	if err != nil {
-		return graphPoint{}, fmt.Errorf(fmt.Sprintf("unable to extract close time from ledger %d: ", sequence), err)
-	}
-
-	return graphPoint{
-		Seq:       sequence,
-		CloseTime: closeTime,
-	}, nil
+	return f.findLedgerForTime(ctx, target, newStart, end)
 }

--- a/internal/input/ledger_range.go
+++ b/internal/input/ledger_range.go
@@ -29,6 +29,14 @@ func GetLedgerRange(startTime, endTime time.Time, env utils.EnvironmentDetails) 
 	}
 	defer ds.Close()
 
+	// Prefer the on-disk schema (written by ledgerexporter) so key generation and
+	// FindOldestLedgerSequence agree with the bucket's actual layout. Fall back to the
+	// hardcoded schema in dsCfg when no manifest is present — matches the tolerance in
+	// utils.CreateLedgerBackend.
+	if loaded, loadErr := datastore.LoadSchema(ctx, ds, dsCfg); loadErr == nil {
+		dsCfg.Schema = loaded
+	}
+
 	finder := &ledgerFinder{
 		ds:     ds,
 		schema: dsCfg.Schema,
@@ -124,42 +132,24 @@ func (f *ledgerFinder) pointAt(ctx context.Context, seq uint32) (ledgerPoint, er
 	return pt, nil
 }
 
-// findLedgerForTime returns the first ledger whose close time is >= target, assuming
-// start.seq <= end.seq and close times are monotonically non-decreasing. The boundary
-// predicate (prev.Unix() < target && curr.Unix() >= target) matches the existing
-// findLedgerForTimeBinary in the history-archive implementation, so golden outputs align.
+// findLedgerForTime returns the smallest ledger sequence in [start.seq, end.seq] whose close
+// time is >= target. Assumes close times are monotonically non-decreasing with sequence, and
+// that the caller has clamped target to [start.closeTime, end.closeTime] so a satisfying seq
+// exists in the range. Uses an iterative lower-bound binary search — it only probes sequences
+// in [start.seq+1, end.seq-1], so it never underflows start.seq or overshoots end.seq.
 func (f *ledgerFinder) findLedgerForTime(ctx context.Context, target time.Time, start, end ledgerPoint) (uint32, error) {
-	if start.seq >= end.seq {
-		return start.seq, nil
-	}
-
-	mid := start.seq + (end.seq-start.seq)/2
-	midPt, err := f.pointAt(ctx, mid)
-	if err != nil {
-		return 0, err
-	}
-
-	if mid > start.seq {
-		prevPt, err := f.pointAt(ctx, mid-1)
+	lo, hi := start.seq, end.seq
+	for lo < hi {
+		mid := lo + (hi-lo)/2
+		midPt, err := f.pointAt(ctx, mid)
 		if err != nil {
 			return 0, err
 		}
-		if prevPt.closeTime.Unix() < target.Unix() && midPt.closeTime.Unix() >= target.Unix() {
-			return mid, nil
+		if midPt.closeTime.Unix() >= target.Unix() {
+			hi = mid
+		} else {
+			lo = mid + 1
 		}
 	}
-
-	if midPt.closeTime.Unix() > target.Unix() {
-		newEnd, err := f.pointAt(ctx, mid-1)
-		if err != nil {
-			return 0, err
-		}
-		return f.findLedgerForTime(ctx, target, start, newEnd)
-	}
-
-	newStart, err := f.pointAt(ctx, mid+1)
-	if err != nil {
-		return 0, err
-	}
-	return f.findLedgerForTime(ctx, target, newStart, end)
+	return lo, nil
 }

--- a/internal/input/ledger_range.go
+++ b/internal/input/ledger_range.go
@@ -29,13 +29,15 @@ func GetLedgerRange(startTime, endTime time.Time, env utils.EnvironmentDetails) 
 	}
 	defer ds.Close()
 
-	// Prefer the on-disk schema (written by ledgerexporter) so key generation and
-	// FindOldestLedgerSequence agree with the bucket's actual layout. Fall back to the
-	// hardcoded schema in dsCfg when no manifest is present — matches the tolerance in
-	// utils.CreateLedgerBackend.
-	if loaded, loadErr := datastore.LoadSchema(ctx, ds, dsCfg); loadErr == nil {
-		dsCfg.Schema = loaded
+	// Use the on-disk schema (written by ledgerexporter) so key generation and
+	// FindOldestLedgerSequence agree with the bucket's actual layout. LoadSchema also
+	// surfaces mismatches between the bucket's manifest and the local config, which we
+	// want to fail on rather than silently paper over with wrong object keys.
+	schema, err := datastore.LoadSchema(ctx, ds, dsCfg)
+	if err != nil {
+		return 0, 0, fmt.Errorf("unable to load datastore schema: %w", err)
 	}
+	dsCfg.Schema = schema
 
 	finder := &ledgerFinder{
 		ds:     ds,

--- a/internal/input/ledger_range.go
+++ b/internal/input/ledger_range.go
@@ -63,6 +63,10 @@ func GetLedgerRange(startTime, endTime time.Time, env utils.EnvironmentDetails) 
 		return 0, 0, err
 	}
 
+	if err := checkTimesWithinDatastore(startTime, endTime, latestPt); err != nil {
+		return 0, 0, err
+	}
+
 	// Clamp requested times to the datastore's available range (same semantics as the
 	// history-archive-backed implementation's limitLedgerRange).
 	if startTime.Before(oldestPt.closeTime) {
@@ -86,6 +90,26 @@ func GetLedgerRange(startTime, endTime time.Time, env utils.EnvironmentDetails) 
 	}
 
 	return int64(startLedger), int64(endLedger), nil
+}
+
+// maxFutureTolerance bounds how far past the datastore's latest ledger close time a requested
+// start/end time may be before we treat the request as bogus. Ledgers close roughly every 5s,
+// so 10s is one ledger plus a safety margin for close-time jitter.
+const maxFutureTolerance = 10 * time.Second
+
+// checkTimesWithinDatastore rejects requests whose start or end time is more than
+// maxFutureTolerance past the latest ledger's close time. Returning an error here means a
+// caller asking for "now" against a stale datastore fails loudly instead of silently getting
+// clamped to the last available ledger.
+func checkTimesWithinDatastore(startTime, endTime time.Time, latest ledgerPoint) error {
+	cutoff := latest.closeTime.Add(maxFutureTolerance)
+	if startTime.After(cutoff) {
+		return fmt.Errorf("start time %s is more than %s past the latest ledger close time %s", startTime, maxFutureTolerance, latest.closeTime)
+	}
+	if endTime.After(cutoff) {
+		return fmt.Errorf("end time %s is more than %s past the latest ledger close time %s", endTime, maxFutureTolerance, latest.closeTime)
+	}
+	return nil
 }
 
 type ledgerPoint struct {

--- a/internal/input/ledger_range_history_archive.go
+++ b/internal/input/ledger_range_history_archive.go
@@ -216,12 +216,12 @@ func (g graph) limitLedgerRange(start, end *time.Time) error {
 func (g graph) getGraphPoint(sequence int64) (graphPoint, error) {
 	ledger, err := g.Client.GetLedgerHeader(uint32(sequence))
 	if err != nil {
-		return graphPoint{}, fmt.Errorf(fmt.Sprintf("unable to get ledger %d: ", sequence), err)
+		return graphPoint{}, fmt.Errorf("unable to get ledger %d: %w", sequence, err)
 	}
 
 	closeTime, err := utils.ExtractLedgerCloseTime(ledger)
 	if err != nil {
-		return graphPoint{}, fmt.Errorf(fmt.Sprintf("unable to extract close time from ledger %d: ", sequence), err)
+		return graphPoint{}, fmt.Errorf("unable to extract close time from ledger %d: %w", sequence, err)
 	}
 
 	return graphPoint{

--- a/internal/input/ledger_range_history_archive.go
+++ b/internal/input/ledger_range_history_archive.go
@@ -1,0 +1,231 @@
+package input
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/stellar/stellar-etl/v2/internal/utils"
+
+	"github.com/stellar/go-stellar-sdk/historyarchive"
+)
+
+// graphPoint represents a single point in the graph. It includes the ledger sequence and close time (in UTC)
+type graphPoint struct {
+	Seq       int64
+	CloseTime time.Time
+}
+
+/*
+The graph struct is used to calculate ledger ranges from time ranges. It keeps track of its boundaries, and uses its backend to
+retrieve new graphPoints as necessary. As the sequence number increases, so does the close time, so we can use the graph to find
+sequence numbers that correspond to a given close time fairly easily.
+*/
+type graph struct {
+	Client     historyarchive.ArchiveInterface
+	BeginPoint graphPoint
+	EndPoint   graphPoint
+}
+
+const avgCloseTime = time.Second * 5 // average time to close a stellar ledger
+
+// GetLedgerRangeHistoryArchive calculates the ledger range that spans the provided date range by
+// binary-searching the Stellar history archives. Preserved for reference and for programmatic use;
+// the CLI now uses the GCS-datastore-backed GetLedgerRange in ledger_range.go.
+func GetLedgerRangeHistoryArchive(startTime, endTime time.Time, isTest bool, isFuture bool) (int64, int64, error) {
+	startTime = startTime.UTC()
+	endTime = endTime.UTC()
+	commonFlagValues := utils.CommonFlagValues{
+		IsTest:   isTest,
+		IsFuture: isFuture,
+	}
+	env := utils.GetEnvironmentDetails(commonFlagValues)
+
+	if startTime.After(endTime) {
+		return 0, 0, fmt.Errorf("start time must be less than or equal to the end time")
+	}
+
+	graph, err := createNewGraph(env.ArchiveURLs)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	err = graph.limitLedgerRange(&startTime, &endTime)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// Ledger sequence 2 is the start ledger because the genesis ledger (ledger 1), has a close time of 0 in Unix time.
+	// The second ledger has a valid close time that matches with the network start time.
+	startLedger, err := graph.findLedgerForDate(2, startTime, map[int64]struct{}{})
+	if err != nil {
+		return 0, 0, err
+	}
+
+	endLedger, err := graph.findLedgerForDate(2, endTime, map[int64]struct{}{})
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return startLedger, endLedger, nil
+}
+
+// createNewGraph makes a new graph with the endpoints equal to the network's endpoints
+func createNewGraph(archiveURLs []string) (graph, error) {
+	graph := graph{}
+	archive, err := utils.CreateHistoryArchiveClient(archiveURLs)
+	if err != nil {
+		return graph, err
+	}
+
+	graph.Client = archive
+
+	secondLedgerPoint, err := graph.getGraphPoint(2) // the second ledger has a real close time, unlike the 1970s close time of the genesis ledger
+	if err != nil {
+		return graph, err
+	}
+
+	graph.BeginPoint = secondLedgerPoint
+
+	root, err := graph.Client.GetRootHAS()
+	if err != nil {
+		return graph, err
+	}
+
+	latestPoint, err := graph.getGraphPoint(int64(root.CurrentLedger))
+	if err != nil {
+		return graph, err
+	}
+
+	graph.EndPoint = latestPoint
+	return graph, nil
+}
+
+func (g graph) findLedgerForTimeBinary(targetTime time.Time, start, end graphPoint) (int64, error) {
+	if end.Seq >= 2 {
+		middleLedger := start.Seq + (end.Seq-start.Seq)/2
+		middleTime, err := g.getGraphPoint(middleLedger)
+		if err != nil {
+			return 0, err
+		}
+
+		// check if middle element is the one to choose
+		if middleLedger > 1 {
+			prevLedger := middleLedger - 1
+			prevTime, err := g.getGraphPoint(prevLedger)
+			if err != nil {
+				return 0, err
+			}
+
+			if prevTime.CloseTime.Unix() < targetTime.Unix() && middleTime.CloseTime.Unix() >= targetTime.Unix() {
+				return middleLedger, nil
+			}
+		}
+
+		if middleTime.CloseTime.Unix() > targetTime.Unix() {
+			newEnd, err := g.getGraphPoint(middleLedger - 1)
+			if err != nil {
+				return 0, err
+			}
+
+			return g.findLedgerForTimeBinary(targetTime, start, newEnd)
+		}
+
+		newStart, err := g.getGraphPoint(middleLedger + 1)
+		if err != nil {
+			return 0, err
+		}
+
+		return g.findLedgerForTimeBinary(targetTime, newStart, end)
+	}
+
+	return 0, fmt.Errorf("unable to find ledger with close time %v: ", targetTime)
+}
+
+// findLedgerForDate recursively searches for the ledger that was closed on or directly after targetTime
+func (g graph) findLedgerForDate(currentLedger int64, targetTime time.Time, seenLedgers map[int64]struct{}) (int64, error) {
+	seenLedgers[currentLedger] = struct{}{}
+
+	currentPoint, err := g.getGraphPoint(currentLedger)
+	if err != nil {
+		return 0, err
+	}
+
+	if currentLedger > 1 {
+		prevLedger := currentLedger - 1
+		prevTime, err := g.getGraphPoint(prevLedger)
+		if err != nil {
+			return 0, err
+		}
+
+		if prevTime.CloseTime.Unix() < targetTime.Unix() && currentPoint.CloseTime.Unix() >= targetTime.Unix() {
+			return currentLedger, nil
+		}
+	}
+
+	timeDiff := targetTime.Sub(currentPoint.CloseTime).Seconds()
+	ledgerOffset := int64(timeDiff / avgCloseTime.Seconds())
+	if ledgerOffset == 0 {
+		if timeDiff > 0 {
+			ledgerOffset = 1
+		} else {
+			ledgerOffset = -1
+		}
+	}
+
+	newLedger := currentLedger + ledgerOffset
+
+	if newLedger > g.EndPoint.Seq {
+		newLedger = g.EndPoint.Seq
+	} else if newLedger < g.BeginPoint.Seq {
+		// since we started with BeginPoint, returning to it would create an infinite cycle;
+		newLedger = g.BeginPoint.Seq + 1
+	}
+
+	// if we have already seen this ledger, it means the algorithm is trapped in a cycle; use binary search instead (slower but will find the ledger)
+	if _, exists := seenLedgers[newLedger]; exists {
+		// since we have already calculated the current point, we can use it as the upper or lower bound.
+		// This way, the binary search doesn't have to search the entire space
+		if ledgerOffset > 0 {
+			return g.findLedgerForTimeBinary(targetTime, currentPoint, g.EndPoint)
+		}
+
+		return g.findLedgerForTimeBinary(targetTime, g.BeginPoint, currentPoint)
+	}
+
+	return g.findLedgerForDate(newLedger, targetTime, seenLedgers)
+}
+
+// limitLedgerRange restricts start and end by setting them to be the edges of the network's range if they are outside that range
+func (g graph) limitLedgerRange(start, end *time.Time) error {
+	if start.Before(g.BeginPoint.CloseTime) {
+		*start = g.BeginPoint.CloseTime
+	} else if start.After(g.EndPoint.CloseTime) {
+		*start = g.EndPoint.CloseTime
+	}
+
+	if end.After(g.EndPoint.CloseTime) {
+		*end = g.EndPoint.CloseTime
+	} else if end.Before(g.BeginPoint.CloseTime) {
+		*end = g.BeginPoint.CloseTime
+	}
+
+	return nil
+}
+
+// getGraphPoint gets the graphPoint representation of the ledger with the provided sequence number
+func (g graph) getGraphPoint(sequence int64) (graphPoint, error) {
+	ledger, err := g.Client.GetLedgerHeader(uint32(sequence))
+	if err != nil {
+		return graphPoint{}, fmt.Errorf(fmt.Sprintf("unable to get ledger %d: ", sequence), err)
+	}
+
+	closeTime, err := utils.ExtractLedgerCloseTime(ledger)
+	if err != nil {
+		return graphPoint{}, fmt.Errorf(fmt.Sprintf("unable to extract close time from ledger %d: ", sequence), err)
+	}
+
+	return graphPoint{
+		Seq:       sequence,
+		CloseTime: closeTime,
+	}, nil
+}

--- a/internal/input/ledger_range_test.go
+++ b/internal/input/ledger_range_test.go
@@ -1,0 +1,225 @@
+package input
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stellar/go-stellar-sdk/support/compressxdr"
+	"github.com/stellar/go-stellar-sdk/support/datastore"
+	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// testSchema mirrors the "one ledger per file, one file per partition" layout so that each
+// sequence maps to a distinct object key and we can target mock expectations precisely.
+var testSchema = datastore.DataStoreSchema{LedgersPerFile: 1, FilesPerPartition: 1}
+
+// encodedBatch returns a zstd-compressed LedgerCloseMetaBatch containing a single ledger with
+// the given close time — matching the on-disk format that pointAt decodes from the datastore.
+func encodedBatch(t *testing.T, seq uint32, closeTime time.Time) []byte {
+	t.Helper()
+	batch := xdr.LedgerCloseMetaBatch{
+		StartSequence: xdr.Uint32(seq),
+		EndSequence:   xdr.Uint32(seq),
+		LedgerCloseMetas: []xdr.LedgerCloseMeta{
+			{
+				V: 0,
+				V0: &xdr.LedgerCloseMetaV0{
+					LedgerHeader: xdr.LedgerHeaderHistoryEntry{
+						Header: xdr.LedgerHeader{
+							LedgerSeq: xdr.Uint32(seq),
+							ScpValue: xdr.StellarValue{
+								CloseTime: xdr.TimePoint(closeTime.Unix()),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	_, err := compressxdr.NewXDREncoder(compressxdr.DefaultCompressor, batch).WriteTo(&buf)
+	require.NoError(t, err)
+	return buf.Bytes()
+}
+
+// expectGetFile sets up a mock expectation that returns a freshly-encoded batch for the given
+// sequence. Each call gets its own io.ReadCloser because pointAt closes the reader.
+func expectGetFile(t *testing.T, ds *datastore.MockDataStore, seq uint32, closeTime time.Time) *mock.Call {
+	t.Helper()
+	payload := encodedBatch(t, seq, closeTime)
+	key := testSchema.GetObjectKeyFromSequenceNumber(seq)
+	return ds.On("GetFile", mock.Anything, key).Return(
+		io.NopCloser(bytes.NewReader(payload)), nil,
+	)
+}
+
+func newFinder(ds datastore.DataStore) *ledgerFinder {
+	return &ledgerFinder{
+		ds:     ds,
+		schema: testSchema,
+		cache:  map[uint32]ledgerPoint{},
+	}
+}
+
+func TestLedgerFinderPointAtReturnsCloseTime(t *testing.T) {
+	ds := &datastore.MockDataStore{}
+	defer ds.AssertExpectations(t)
+
+	closeTime := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	expectGetFile(t, ds, 100, closeTime).Once()
+
+	pt, err := newFinder(ds).pointAt(context.Background(), 100)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(100), pt.seq)
+	assert.Equal(t, closeTime.Unix(), pt.closeTime.Unix())
+}
+
+func TestLedgerFinderPointAtCachesRepeatCalls(t *testing.T) {
+	ds := &datastore.MockDataStore{}
+	defer ds.AssertExpectations(t)
+
+	closeTime := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	// Once() asserts that a second pointAt for the same seq serves from cache rather than re-fetching.
+	expectGetFile(t, ds, 200, closeTime).Once()
+
+	finder := newFinder(ds)
+	first, err := finder.pointAt(context.Background(), 200)
+	require.NoError(t, err)
+	second, err := finder.pointAt(context.Background(), 200)
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+}
+
+func TestLedgerFinderPointAtGetFileError(t *testing.T) {
+	ds := &datastore.MockDataStore{}
+	defer ds.AssertExpectations(t)
+
+	key := testSchema.GetObjectKeyFromSequenceNumber(42)
+	ds.On("GetFile", mock.Anything, key).Return(nil, errors.New("object not found")).Once()
+
+	_, err := newFinder(ds).pointAt(context.Background(), 42)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to fetch ledger 42")
+	assert.Contains(t, err.Error(), "object not found")
+}
+
+func TestLedgerFinderPointAtDecodeError(t *testing.T) {
+	ds := &datastore.MockDataStore{}
+	defer ds.AssertExpectations(t)
+
+	key := testSchema.GetObjectKeyFromSequenceNumber(7)
+	// Garbage bytes — not a valid zstd stream, so the decoder must fail and the error must surface.
+	ds.On("GetFile", mock.Anything, key).Return(
+		io.NopCloser(bytes.NewReader([]byte("not a real zstd batch"))), nil,
+	).Once()
+
+	_, err := newFinder(ds).pointAt(context.Background(), 7)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to decode batch for ledger 7")
+}
+
+// findLedgerForTime tests. The boundary predicate returns the first ledger whose close time
+// is >= target, matching ledger_range_history_archive.go's findLedgerForTimeBinary so golden
+// outputs agree between the two backends.
+func TestLedgerFinderFindLedgerForTime(t *testing.T) {
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Ledger N has close time base + N seconds — monotonically non-decreasing as required.
+	closeAt := func(seq uint32) time.Time { return base.Add(time.Duration(seq) * time.Second) }
+
+	tests := []struct {
+		name     string
+		start    uint32
+		end      uint32
+		target   time.Time
+		expected uint32
+	}{
+		{
+			name:     "target aligns with a ledger close time",
+			start:    1,
+			end:      16,
+			target:   closeAt(10),
+			expected: 10,
+		},
+		{
+			name: "sub-second target is floored to ledger with matching Unix second",
+			// Close-time comparison is Unix()-based, so the 500ms offset doesn't advance the
+			// target past ledger 7. Predicate: prev(6) < 7 && curr(7) >= 7 → returns 7.
+			start:    1,
+			end:      16,
+			target:   closeAt(7).Add(500 * time.Millisecond),
+			expected: 7,
+		},
+		{
+			name:     "target at start boundary returns start",
+			start:    1,
+			end:      16,
+			target:   closeAt(1),
+			expected: 1,
+		},
+		{
+			name:     "target at end boundary returns end",
+			start:    1,
+			end:      16,
+			target:   closeAt(16),
+			expected: 16,
+		},
+		{
+			name:     "start equals end returns start without probing",
+			start:    5,
+			end:      5,
+			target:   closeAt(5),
+			expected: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := &datastore.MockDataStore{}
+			defer ds.AssertExpectations(t)
+
+			// Serve every ledger in the range — we can't predict exactly which seqs the binary
+			// search probes, so make them all available and let the cache suppress duplicate GETs.
+			for seq := tt.start; seq <= tt.end; seq++ {
+				expectGetFile(t, ds, seq, closeAt(seq)).Maybe()
+			}
+
+			finder := newFinder(ds)
+			startPt := ledgerPoint{seq: tt.start, closeTime: closeAt(tt.start)}
+			endPt := ledgerPoint{seq: tt.end, closeTime: closeAt(tt.end)}
+			finder.cache[tt.start] = startPt
+			finder.cache[tt.end] = endPt
+
+			got, err := finder.findLedgerForTime(context.Background(), tt.target, startPt, endPt)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestLedgerFinderFindLedgerForTimePropagatesDatastoreError(t *testing.T) {
+	ds := &datastore.MockDataStore{}
+	defer ds.AssertExpectations(t)
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	start := ledgerPoint{seq: 1, closeTime: base.Add(1 * time.Second)}
+	end := ledgerPoint{seq: 10, closeTime: base.Add(10 * time.Second)}
+
+	// Any GetFile call (the search will probe at least one interior seq) returns an error.
+	ds.On("GetFile", mock.Anything, mock.Anything).Return(nil, errors.New("transient failure"))
+
+	finder := newFinder(ds)
+	finder.cache[start.seq] = start
+	finder.cache[end.seq] = end
+
+	_, err := finder.findLedgerForTime(context.Background(), base.Add(5*time.Second), start, end)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "transient failure")
+}

--- a/internal/input/ledger_range_test.go
+++ b/internal/input/ledger_range_test.go
@@ -230,6 +230,73 @@ func TestLedgerFinderFindLedgerForTime(t *testing.T) {
 	}
 }
 
+// checkTimesWithinDatastore guards against requests that reach more than maxFutureTolerance
+// past the latest ledger's close time. The tolerance is inclusive of the cutoff instant
+// (comparison uses .After), so a time exactly at latest+10s is still accepted.
+func TestCheckTimesWithinDatastore(t *testing.T) {
+	latest := ledgerPoint{
+		seq:       100,
+		closeTime: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	withinTolerance := latest.closeTime.Add(5 * time.Second)
+	atCutoff := latest.closeTime.Add(maxFutureTolerance)
+	pastCutoff := latest.closeTime.Add(maxFutureTolerance + time.Second)
+
+	tests := []struct {
+		name       string
+		startTime  time.Time
+		endTime    time.Time
+		wantErr    bool
+		wantErrSub string
+	}{
+		{
+			name:      "both times before latest close time",
+			startTime: latest.closeTime.Add(-time.Hour),
+			endTime:   latest.closeTime.Add(-time.Minute),
+			wantErr:   false,
+		},
+		{
+			name:      "both times within tolerance",
+			startTime: withinTolerance,
+			endTime:   withinTolerance,
+			wantErr:   false,
+		},
+		{
+			name:      "both times exactly at cutoff are accepted",
+			startTime: atCutoff,
+			endTime:   atCutoff,
+			wantErr:   false,
+		},
+		{
+			name:       "start time past cutoff returns error naming start",
+			startTime:  pastCutoff,
+			endTime:    pastCutoff,
+			wantErr:    true,
+			wantErrSub: "start time",
+		},
+		{
+			name:       "only end time past cutoff returns error naming end",
+			startTime:  withinTolerance,
+			endTime:    pastCutoff,
+			wantErr:    true,
+			wantErrSub: "end time",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkTimesWithinDatastore(tt.startTime, tt.endTime, latest)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrSub)
+				assert.Contains(t, err.Error(), maxFutureTolerance.String())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestLedgerFinderFindLedgerForTimePropagatesDatastoreError(t *testing.T) {
 	ds := &datastore.MockDataStore{}
 	defer ds.AssertExpectations(t)

--- a/internal/input/ledger_range_test.go
+++ b/internal/input/ledger_range_test.go
@@ -178,6 +178,32 @@ func TestLedgerFinderFindLedgerForTime(t *testing.T) {
 			target:   closeAt(5),
 			expected: 5,
 		},
+		{
+			// Two-element range where target equals start's close time. Under the old recursive
+			// search mid == start.seq caused the boundary check to be skipped and the algorithm
+			// fell through to pointAt(mid+1), returning end instead of start.
+			name:     "two-element range with target at start",
+			start:    5,
+			end:      6,
+			target:   closeAt(5),
+			expected: 5,
+		},
+		{
+			name:     "two-element range with target at end",
+			start:    5,
+			end:      6,
+			target:   closeAt(6),
+			expected: 6,
+		},
+		{
+			// Target strictly between start and end in a two-element range — the only satisfying
+			// seq is end, since end.closeTime is the first >= target.
+			name:     "two-element range with target between",
+			start:    5,
+			end:      6,
+			target:   closeAt(5).Add(500 * time.Millisecond).Add(time.Second),
+			expected: 6,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Swaps the `get_ledger_range_from_times` binary search from the Stellar history archive to the GCS datastore used by the bulk export commands, so the CLI no longer depends on `historyarchive.GetLedgerHeader` for this lookup.
- Preserves the old adaptive-step implementation as `GetLedgerRangeHistoryArchive` in `internal/input/ledger_range_history_archive.go` for reference / programmatic use.
- Adds a `--datastore-path` flag (defaults to `sdf-ledger-close-meta/v1/ledgers`) so callers can point at a different datastore layout.
- Adds unit tests for `pointAt` (fetch, cache, GetFile error, decode error) and the `findLedgerForTime` boundary predicate, including a datastore-error propagation case.

## Test plan
- [x] `go build ./...`
- [x] `go test -v -run 'LedgerFinder' ./internal/input/...`
- [x] `pre-commit run --files ...` (golangci-lint clean)
- [x] Run `make int-test` locally against a datastore bucket to confirm parity with the history-archive implementation on a known time range
- [x] Sanity-check CLI: `./stellar-etl get_ledger_range_from_times --start-time ... --end-time ... --datastore-path sdf-ledger-close-meta/v1/ledgers`