### PR TITLE
Move Dependabot day to Wednesday and ignore major upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "wednesday"
       time: "02:00"
     open-pull-requests-limit: 1
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       all-go-deps:
         applies-to: version-updates
@@ -15,9 +18,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "wednesday"
       time: "02:00"
     open-pull-requests-limit: 1
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       all-actions:
         applies-to: version-updates
@@ -26,9 +32,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "wednesday"
       time: "02:00"
     open-pull-requests-limit: 1
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       all-docker:
         applies-to: version-updates


### PR DESCRIPTION
## Summary

Two small changes to `.github/dependabot.yml`:

1. **Schedule day moved sunday → wednesday** so Dependabot PRs land mid-week and aren't sitting through the weekend.
2. **Major-version upgrades ignored** via `ignore: [{dependency-name: "*", update-types: [version-update:semver-major]}]` on every `updates` entry. Major bumps were repeatedly creating PRs that couldn't pass CI due to transitive constraints (e.g. `apache-airflow-providers-cncf-kubernetes 10.16.1` requiring cryptography ≥44 vs `gcloud-aio-auth` capping at <42; `click 8.3.x` capped by `sqlfluff 3.5.0`). Major upgrades will be done manually when the surrounding deps can absorb them.

For the dbt/airflow repos that previously had a separate `major` group entry, that group is now redundant and removed.

## Test plan

- [ ] Verify YAML is valid (Dependabot will surface a config error in the repo's Insights → Dependency graph → Dependabot tab if not).