### PR TITLE
Bump go-stellar-xdr-json to latest commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stellar/go-stellar-sdk v0.5.0
-	github.com/stellar/go-stellar-xdr-json v0.0.0-20250826185517-ee4033414d38
+	github.com/stellar/go-stellar-xdr-json v0.0.0-20260505215811-c00a3e0c10e6
 	github.com/stretchr/testify v1.11.1
 	github.com/xitongsys/parquet-go v1.6.2
 	github.com/xitongsys/parquet-go-source v0.0.0-20240122235623-d6294584ab18

--- a/go.sum
+++ b/go.sum
@@ -696,8 +696,8 @@ github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMps
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/stellar/go-stellar-sdk v0.5.0 h1:xpOO+ZTyvGz54wTm7pwl2Gf1e6lZl0ExrJ/tKb+Roj4=
 github.com/stellar/go-stellar-sdk v0.5.0/go.mod h1:tLKAQPxa2I5UvGMabBbUXcY3fmgYnfDudrMeK7CDX4w=
-github.com/stellar/go-stellar-xdr-json v0.0.0-20250826185517-ee4033414d38 h1:MpBttv9FXBK9N/rNwjVGIEc4NegoYT9eEQiwtkIHw2E=
-github.com/stellar/go-stellar-xdr-json v0.0.0-20250826185517-ee4033414d38/go.mod h1:UEZ6EvdC3Cou6N46OJ5SXvbWTlod8gOUI/CvhY1JVaM=
+github.com/stellar/go-stellar-xdr-json v0.0.0-20260505215811-c00a3e0c10e6 h1:GyhUAV2HnBtJkCalzF6cBI7cd4KkQeK+HiAoZSvY6AU=
+github.com/stellar/go-stellar-xdr-json v0.0.0-20260505215811-c00a3e0c10e6/go.mod h1:UEZ6EvdC3Cou6N46OJ5SXvbWTlod8gOUI/CvhY1JVaM=
 github.com/stellar/go-xdr v0.0.0-20260312225820-cc2b0611aabf h1:GY1RVbX3Hg7poPXEf6yojjP0hyypvgUgZmCqQU9D0xg=
 github.com/stellar/go-xdr v0.0.0-20260312225820-cc2b0611aabf/go.mod h1:If+U9Z1W5xU97VrOgJandQT+2dN7/iOpkCrxBJEyF80=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
## Summary
- Bumps `github.com/stellar/go-stellar-xdr-json` from `v0.0.0-20250826185517-ee4033414d38` to `v0.0.0-20260505215811-c00a3e0c10e6` to stay current with upstream changes.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `make int-test` passes (XDR JSON encoding still produces matching golden files)