### PR TITLE
Harden Release Drafter workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,37 +31,42 @@ jobs:
 
       - name: Get branch name
         id: getbranch
-        run: echo ::set-output name=BRANCH::${GITHUB_HEAD_REF}
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: echo "BRANCH=$HEAD_REF" >> "$GITHUB_OUTPUT"
 
       # ${{ github.ref }} was not giving v* as tag name, but refs/tags/v* instead, so It had to be abbreviated
       - name: Get latest abbreviated tag
         id: gettag
-        run: echo ::set-output name=TAG::$(git describe --tags $(git rev-list --tags --max-count=1)) # get the latest tag across all branches and put it in the output TAG
+        run: echo "TAG=$(git describe --tags $(git rev-list --tags --max-count=1))" >> "$GITHUB_OUTPUT"
 
       - name: Calculate next version
         id: nextversion
+        env:
+          BRANCH_NAME: ${{ steps.getbranch.outputs.BRANCH }}
+          CURRENT_VERSION: ${{ steps.gettag.outputs.TAG }}
         run: |
-          BRANCH_NAME="${{ steps.getbranch.outputs.BRANCH }}"
-          CURRENT_VERSION="${{ steps.gettag.outputs.TAG }}"
           CURRENT_VERSION="${CURRENT_VERSION#v}"  # Remove the 'v' from the start of the version
           IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
-          if [[ $BRANCH_NAME =~ ^major/ ]]; then
+          if [[ "$BRANCH_NAME" =~ ^major/ ]]; then
             VERSION_PARTS[0]=$((VERSION_PARTS[0] + 1))
             VERSION_PARTS[1]=0
             VERSION_PARTS[2]=0
-          elif [[ $BRANCH_NAME =~ ^minor/ ]]; then
+          elif [[ "$BRANCH_NAME" =~ ^minor/ ]]; then
             VERSION_PARTS[1]=$((VERSION_PARTS[1] + 1))
             VERSION_PARTS[2]=0
           else
             VERSION_PARTS[2]=$((VERSION_PARTS[2] + 1))
           fi
           NEXT_VERSION="v${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"
-          echo ::set-output name=NEXT_VERSION::"$NEXT_VERSION"
+          echo "NEXT_VERSION=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create and publish new tag
+        env:
+          NEXT_VERSION: ${{ steps.nextversion.outputs.NEXT_VERSION }}
         run: |
-          git tag ${{ steps.nextversion.outputs.NEXT_VERSION }}
-          git push origin ${{ steps.nextversion.outputs.NEXT_VERSION }}
+          git tag "$NEXT_VERSION"
+          git push origin "$NEXT_VERSION"
 
       - uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0
         with:

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stellar/go-stellar-sdk v0.5.0
-	github.com/stellar/go-stellar-xdr-json v0.0.0-20250826185517-ee4033414d38
+	github.com/stellar/go-stellar-xdr-json v0.0.0-20260505215811-c00a3e0c10e6
 	github.com/stretchr/testify v1.11.1
 	github.com/xitongsys/parquet-go v1.6.2
 	github.com/xitongsys/parquet-go-source v0.0.0-20240122235623-d6294584ab18

--- a/go.sum
+++ b/go.sum
@@ -696,8 +696,8 @@ github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMps
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/stellar/go-stellar-sdk v0.5.0 h1:xpOO+ZTyvGz54wTm7pwl2Gf1e6lZl0ExrJ/tKb+Roj4=
 github.com/stellar/go-stellar-sdk v0.5.0/go.mod h1:tLKAQPxa2I5UvGMabBbUXcY3fmgYnfDudrMeK7CDX4w=
-github.com/stellar/go-stellar-xdr-json v0.0.0-20250826185517-ee4033414d38 h1:MpBttv9FXBK9N/rNwjVGIEc4NegoYT9eEQiwtkIHw2E=
-github.com/stellar/go-stellar-xdr-json v0.0.0-20250826185517-ee4033414d38/go.mod h1:UEZ6EvdC3Cou6N46OJ5SXvbWTlod8gOUI/CvhY1JVaM=
+github.com/stellar/go-stellar-xdr-json v0.0.0-20260505215811-c00a3e0c10e6 h1:GyhUAV2HnBtJkCalzF6cBI7cd4KkQeK+HiAoZSvY6AU=
+github.com/stellar/go-stellar-xdr-json v0.0.0-20260505215811-c00a3e0c10e6/go.mod h1:UEZ6EvdC3Cou6N46OJ5SXvbWTlod8gOUI/CvhY1JVaM=
 github.com/stellar/go-xdr v0.0.0-20260312225820-cc2b0611aabf h1:GY1RVbX3Hg7poPXEf6yojjP0hyypvgUgZmCqQU9D0xg=
 github.com/stellar/go-xdr v0.0.0-20260312225820-cc2b0611aabf/go.mod h1:If+U9Z1W5xU97VrOgJandQT+2dN7/iOpkCrxBJEyF80=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
## Summary

Migrate the deprecated `::set-output` workflow command to `$GITHUB_OUTPUT`, and pass branch / version values through `env:` rather than re-interpolating them into bash. This:

- Removes the script-injection surface from PR-controlled values flowing into `run:` blocks (matches GitHub's [Actions hardening guide][1]).
- Unblocks future runner-image upgrades that drop `::set-output` support.

Behavior is unchanged — the workflow still produces the same `BRANCH`, `TAG`, and `NEXT_VERSION` step outputs and uses them in the same downstream steps.

Impact today is limited (workflow only runs on merged PRs from upstream branches), but the fix is mechanical defense-in-depth.

## Test plan

- [ ] After merge, the next merged PR triggers Release Drafter and tags + publishes a release as before.

[1]: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections