### PR TITLE
Add Claude Code workflow (WIF auth)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,140 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+  workflow_dispatch:
+
+jobs:
+  claude:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        (github.event.review.author_association == 'OWNER' ||
+         github.event.review.author_association == 'COLLABORATOR')) ||
+      (github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        (github.event.issue.author_association == 'OWNER' ||
+         github.event.issue.author_association == 'COLLABORATOR'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    env:
+      ANTHROPIC_FEDERATION_RULE_ID: ${{ secrets.ANTHROPIC_FEDERATION_RULE_ID }}
+      ANTHROPIC_ORGANIZATION_ID: ${{ secrets.ANTHROPIC_ORGANIZATION_ID }}
+      ANTHROPIC_SERVICE_ACCOUNT_ID: ${{ secrets.ANTHROPIC_SERVICE_ACCOUNT_ID }}
+      ANTHROPIC_WORKSPACE_ID: ${{ secrets.ANTHROPIC_WORKSPACE_ID }}
+    steps:
+      - name: Resolve checkout target
+        id: checkout-target
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const eventName = context.eventName;
+
+            if (eventName === 'pull_request_review' || eventName === 'pull_request_review_comment') {
+              const pr = context.payload.pull_request;
+              core.setOutput('repository', pr.head.repo.full_name);
+              core.setOutput('ref', pr.head.ref);
+              return;
+            }
+
+            if (eventName === 'issue_comment' && context.payload.issue?.pull_request) {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.issue.number,
+              });
+
+              core.setOutput('repository', pr.data.head.repo.full_name);
+              core.setOutput('ref', pr.data.head.ref);
+              return;
+            }
+
+            core.setOutput('repository', '');
+            core.setOutput('ref', '');
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ steps.checkout-target.outputs.repository || github.repository }}
+          ref: ${{ steps.checkout-target.outputs.ref || github.ref }}
+          fetch-depth: 1
+
+      - name: Exchange GitHub OIDC token for Anthropic access token
+        id: anthropic-auth
+        run: |
+          set -euo pipefail
+
+          JWT=$(curl -sS -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=https://api.anthropic.com" \
+            | jq -r .value)
+
+          if [ -z "$JWT" ] || [ "$JWT" = "null" ]; then
+            echo "Failed to fetch GitHub OIDC token"
+            exit 1
+          fi
+
+          RESPONSE=$(jq -n \
+            --arg assertion "$JWT" \
+            --arg rule "$ANTHROPIC_FEDERATION_RULE_ID" \
+            --arg org "$ANTHROPIC_ORGANIZATION_ID" \
+            --arg svac "$ANTHROPIC_SERVICE_ACCOUNT_ID" \
+            --arg workspace "$ANTHROPIC_WORKSPACE_ID" \
+            '{grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+              assertion: $assertion,
+              federation_rule_id: $rule,
+              organization_id: $org,
+              service_account_id: $svac,
+              workspace_id: $workspace}' \
+            | curl -sS https://api.anthropic.com/v1/oauth/token \
+                -H "content-type: application/json" \
+                --data-binary @-)
+
+          ACCESS_TOKEN=$(echo "$RESPONSE" | jq -r '.access_token // empty')
+          if [ -z "$ACCESS_TOKEN" ]; then
+            echo "Failed to obtain Anthropic access token. Response:"
+            echo "$RESPONSE" | jq -r '.error // .'
+            exit 1
+          fi
+
+          echo "::add-mask::$ACCESS_TOKEN"
+          echo "access_token=$ACCESS_TOKEN" >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude Code
+        id: claude
+        if: github.event_name != 'workflow_dispatch'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ steps.anthropic-auth.outputs.access_token }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stellar/go-stellar-sdk v0.5.0
-	github.com/stellar/go-stellar-xdr-json v0.0.0-20250826185517-ee4033414d38
+	github.com/stellar/go-stellar-xdr-json v0.0.0-20260505215811-c00a3e0c10e6
 	github.com/stretchr/testify v1.11.1
 	github.com/xitongsys/parquet-go v1.6.2
 	github.com/xitongsys/parquet-go-source v0.0.0-20240122235623-d6294584ab18

--- a/go.sum
+++ b/go.sum
@@ -696,8 +696,8 @@ github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMps
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/stellar/go-stellar-sdk v0.5.0 h1:xpOO+ZTyvGz54wTm7pwl2Gf1e6lZl0ExrJ/tKb+Roj4=
 github.com/stellar/go-stellar-sdk v0.5.0/go.mod h1:tLKAQPxa2I5UvGMabBbUXcY3fmgYnfDudrMeK7CDX4w=
-github.com/stellar/go-stellar-xdr-json v0.0.0-20250826185517-ee4033414d38 h1:MpBttv9FXBK9N/rNwjVGIEc4NegoYT9eEQiwtkIHw2E=
-github.com/stellar/go-stellar-xdr-json v0.0.0-20250826185517-ee4033414d38/go.mod h1:UEZ6EvdC3Cou6N46OJ5SXvbWTlod8gOUI/CvhY1JVaM=
+github.com/stellar/go-stellar-xdr-json v0.0.0-20260505215811-c00a3e0c10e6 h1:GyhUAV2HnBtJkCalzF6cBI7cd4KkQeK+HiAoZSvY6AU=
+github.com/stellar/go-stellar-xdr-json v0.0.0-20260505215811-c00a3e0c10e6/go.mod h1:UEZ6EvdC3Cou6N46OJ5SXvbWTlod8gOUI/CvhY1JVaM=
 github.com/stellar/go-xdr v0.0.0-20260312225820-cc2b0611aabf h1:GY1RVbX3Hg7poPXEf6yojjP0hyypvgUgZmCqQU9D0xg=
 github.com/stellar/go-xdr v0.0.0-20260312225820-cc2b0611aabf/go.mod h1:If+U9Z1W5xU97VrOgJandQT+2dN7/iOpkCrxBJEyF80=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
## Summary
Adds the Claude Code GitHub Actions workflow to this repo, mirroring the production setup in stellar/stellar-dbt#833.

This lets repo `OWNER`s and `COLLABORATOR`s invoke Claude on PRs and issues by `@claude`-tagging in a comment, review, or issue body.

## How it works
- Triggers on `issue_comment`, `pull_request_review_comment`, `pull_request_review`, `issues`, and `workflow_dispatch`
- Job-level `if:` gate restricts invocation to `OWNER` / `COLLABORATOR` (this is a **public** repo, so `MEMBER` is intentionally excluded — only the org owner and explicitly-invited collaborators can invoke)
- Authenticates to Anthropic via GitHub OIDC + Workload Identity Federation — no long-lived API key in repo secrets
- Read-only `permissions:` block (no `contents: write`); no `Bash(...)` allowlist on the action

## Setup required before this can be used (repo admin)
- [ ] Add four GitHub Actions secrets (same values as `stellar-dbt`, the federation rule is shared):
  - `ANTHROPIC_FEDERATION_RULE_ID`
  - `ANTHROPIC_ORGANIZATION_ID`
  - `ANTHROPIC_SERVICE_ACCOUNT_ID`
  - `ANTHROPIC_WORKSPACE_ID`
- [ ] Confirm the Anthropic federation rule's `repository` claim filter accepts `stellar/stellar-etl`

## Test plan
- [ ] After secrets are added, `gh workflow run claude.yml --ref minor/add-claude-workflow` runs and the auth step succeeds
- [ ] An `@claude` comment from a collaborator on a PR successfully invokes the action