### PR TITLE
Label JSON export files with .json extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Commands have the option to read from testnet with the `--testnet` flag, from fu
 
 ## **Export Commands**
 
+Export commands write newline-delimited JSON: each `.json` output file contains one JSON object per line, not a single JSON array.
+
 These commands export information using the [Ledger Exporter](https://github.com/stellar/go/blob/master/exp/services/ledgerexporter/README.md) output files within a specified datastore (currently [datastore](https://github.com/stellar/go/tree/master/support/datastore) only supports GCS). This allows users to provide a start and end ledger range. The commands in this category export a list of everything that occurred within the provided range. All of the ranges are inclusive.
 
 > _*NOTE:*_ The datastore must contain the expected compressed LedgerCloseMetaBatch XDR binary files as exported from [Ledger Exporter](https://github.com/stellar/go/blob/master/exp/services/ledgerexporter/README.md#exported-files).
@@ -161,7 +163,7 @@ These commands export information using the [Ledger Exporter](https://github.com
 | strict-export  | If set, transform errors will be fatal                                                        | true                    |
 | testnet        | If set, will connect to Testnet instead of Pubnet                                             | false                   |
 | futurenet      | If set, will connect to Futurenet instead of Pubnet                                           | false                   |
-| extra-fields   | Additional fields to append to output jsons. Used for appending metadata                      | ---                     |
+| extra-fields   | Additional fields to append to output JSON rows. Used for appending metadata                  | ---                     |
 | captive-core   | If set, run captive core to retrieve data. Otherwise use TxMeta file datastore                | false                   |
 | datastore-path | Datastore bucket path to read txmeta files from                                               | ledger-exporter/ledgers |
 | buffer-size    | Buffer size sets the max limit for the number of txmeta files that can be held in memory      | 1000                    |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ docker run --platform linux/amd64 -it stellar/stellar-etl:latest /bin/bash
    Example command to export ledger data
 
 ```sh
-root@71890b878fca:/etl/data# stellar-etl export_ledgers --start-ledger 1000 --end-ledger 500000 --output exported_ledgers.txt
+root@71890b878fca:/etl/data# stellar-etl export_ledgers --start-ledger 1000 --end-ledger 500000 --output exported_ledgers.json
 ```
 
 > _*Note:*_ If using the GCS datastore, you can run the following to set GCP credentials to use in your shell
@@ -185,7 +185,7 @@ These commands export information using the [Ledger Exporter](https://github.com
 
 ```bash
 > stellar-etl export_ledgers --start-ledger 1000 \
---end-ledger 500000 --output exported_ledgers.txt
+--end-ledger 500000 --output exported_ledgers.json
 ```
 
 This command exports ledgers within the provided range.
@@ -198,7 +198,7 @@ This command exports ledgers within the provided range.
 
 ```bash
 > stellar-etl export_transactions --start-ledger 1000 \
---end-ledger 500000 --output exported_transactions.txt
+--end-ledger 500000 --output exported_transactions.json
 ```
 
 This command exports transactions within the provided range.
@@ -211,7 +211,7 @@ This command exports transactions within the provided range.
 
 ```bash
 > stellar-etl export_operations --start-ledger 1000 \
---end-ledger 500000 --output exported_operations.txt
+--end-ledger 500000 --output exported_operations.json
 ```
 
 This command exports operations within the provided range.
@@ -224,7 +224,7 @@ This command exports operations within the provided range.
 
 ```bash
 > stellar-etl export_effects --start-ledger 1000 \
---end-ledger 500000 --output exported_effects.txt
+--end-ledger 500000 --output exported_effects.json
 ```
 
 This command exports effects within the provided range.
@@ -238,7 +238,7 @@ This command exports effects within the provided range.
 ```bash
 > stellar-etl export_assets \
 --start-ledger 1000 \
---end-ledger 500000 --output exported_assets.txt
+--end-ledger 500000 --output exported_assets.json
 ```
 
 Exports the assets that are created from payment operations over a specified ledger range.
@@ -252,7 +252,7 @@ Exports the assets that are created from payment operations over a specified led
 ```bash
 > stellar-etl export_trades \
 --start-ledger 1000 \
---end-ledger 500000 --output exported_trades.txt
+--end-ledger 500000 --output exported_trades.json
 ```
 
 Exports trade data within the specified range to an output file
@@ -266,7 +266,7 @@ Exports trade data within the specified range to an output file
 ```bash
 > stellar-etl export_diagnostic_events \
 --start-ledger 1000 \
---end-ledger 500000 --output export_diagnostic_events.txt
+--end-ledger 500000 --output export_diagnostic_events.json
 ```
 
 Exports diagnostic events data within the specified range to an output file

--- a/cmd/command_utils.go
+++ b/cmd/command_utils.go
@@ -103,7 +103,7 @@ func PrintTransformStats(attempts, failures int) {
 }
 
 func exportFilename(start, end uint32, dataType string) string {
-	return fmt.Sprintf("%d-%d-%s.txt", start, end-1, dataType)
+	return fmt.Sprintf("%d-%d-%s.json", start, end-1, dataType)
 }
 
 func exportParquetFilename(start, end uint32, dataType string) string {

--- a/cmd/command_utils_test.go
+++ b/cmd/command_utils_test.go
@@ -1,0 +1,12 @@
+package cmd
+
+import "testing"
+
+func TestExportFilenameUsesJSONExtension(t *testing.T) {
+	got := exportFilename(100, 201, "transactions")
+	want := "100-200-transactions.json"
+
+	if got != want {
+		t.Fatalf("exportFilename() = %q, want %q", got, want)
+	}
+}

--- a/cmd/export_assets.go
+++ b/cmd/export_assets.go
@@ -16,7 +16,7 @@ var assetsCmd = &cobra.Command{
 	Short: "Exports the assets data over a specified range.",
 	Long: `Exports the assets that are created from payment operations over a
 specified ledger range. Ledgers are processed in batches of batch-size; each
-batch produces one file named {start}-{end}-assets.txt in the output folder.
+batch produces one file named {start}-{end}-assets.json in the output folder.
 Duplicate assets are deduplicated across the entire run.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "assets", new(transform.AssetOutputParquet), newAssetsProcessor())

--- a/cmd/export_assets.go
+++ b/cmd/export_assets.go
@@ -16,7 +16,8 @@ var assetsCmd = &cobra.Command{
 	Short: "Exports the assets data over a specified range.",
 	Long: `Exports the assets that are created from payment operations over a
 specified ledger range. Ledgers are processed in batches of batch-size; each
-batch produces one file named {start}-{end}-assets.json in the output folder.
+batch produces one newline-delimited JSON file named
+{start}-{end}-assets.json in the output folder.
 Duplicate assets are deduplicated across the entire run.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "assets", new(transform.AssetOutputParquet), newAssetsProcessor())

--- a/cmd/export_contract_events.go
+++ b/cmd/export_contract_events.go
@@ -14,9 +14,9 @@ import (
 var contractEventsCmd = &cobra.Command{
 	Use:   "export_contract_events",
 	Short: "Exports the contract events over a specified range.",
-	Long: `Exports the contract events over a specified range. Ledgers are
-processed in batches of batch-size; each batch produces one file named
-{start}-{end}-contract_events.json in the output folder.`,
+Long: `Exports the contract events over a specified range. Ledgers are
+processed in batches of batch-size; each batch produces one newline-delimited
+JSON file named {start}-{end}-contract_events.json in the output folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "contract_events", new(transform.ContractEventOutputParquet), processContractEvents)
 	},

--- a/cmd/export_contract_events.go
+++ b/cmd/export_contract_events.go
@@ -16,7 +16,7 @@ var contractEventsCmd = &cobra.Command{
 	Short: "Exports the contract events over a specified range.",
 	Long: `Exports the contract events over a specified range. Ledgers are
 processed in batches of batch-size; each batch produces one file named
-{start}-{end}-contract_events.txt in the output folder.`,
+{start}-{end}-contract_events.json in the output folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "contract_events", new(transform.ContractEventOutputParquet), processContractEvents)
 	},

--- a/cmd/export_effects.go
+++ b/cmd/export_effects.go
@@ -16,7 +16,7 @@ var effectsCmd = &cobra.Command{
 	Short: "Exports the effects data over a specified range.",
 	Long: `Exports the effects data over a specified range. Ledgers are
 processed in batches of batch-size; each batch produces one file named
-{start}-{end}-effects.txt in the output folder.`,
+{start}-{end}-effects.json in the output folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "effects", new(transform.EffectOutputParquet), processEffects)
 	},

--- a/cmd/export_effects.go
+++ b/cmd/export_effects.go
@@ -14,9 +14,9 @@ import (
 var effectsCmd = &cobra.Command{
 	Use:   "export_effects",
 	Short: "Exports the effects data over a specified range.",
-	Long: `Exports the effects data over a specified range. Ledgers are
-processed in batches of batch-size; each batch produces one file named
-{start}-{end}-effects.json in the output folder.`,
+Long: `Exports the effects data over a specified range. Ledgers are
+processed in batches of batch-size; each batch produces one newline-delimited
+JSON file named {start}-{end}-effects.json in the output folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "effects", new(transform.EffectOutputParquet), processEffects)
 	},

--- a/cmd/export_ledger_transaction.go
+++ b/cmd/export_ledger_transaction.go
@@ -16,7 +16,7 @@ var ledgerTransactionCmd = &cobra.Command{
 	Short: "Exports the ledger_transaction data over a specified range.",
 	Long: `Exports the ledger_transaction data over a specified range. Ledgers
 are processed in batches of batch-size; each batch produces one file named
-{start}-{end}-ledger_transaction.txt in the output folder.`,
+{start}-{end}-ledger_transaction.json in the output folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "ledger_transaction", nil, processLedgerTransaction)
 	},

--- a/cmd/export_ledger_transaction.go
+++ b/cmd/export_ledger_transaction.go
@@ -14,9 +14,10 @@ import (
 var ledgerTransactionCmd = &cobra.Command{
 	Use:   "export_ledger_transaction",
 	Short: "Exports the ledger_transaction data over a specified range.",
-	Long: `Exports the ledger_transaction data over a specified range. Ledgers
-are processed in batches of batch-size; each batch produces one file named
-{start}-{end}-ledger_transaction.json in the output folder.`,
+Long: `Exports the ledger_transaction data over a specified range. Ledgers
+are processed in batches of batch-size; each batch produces one
+newline-delimited JSON file named {start}-{end}-ledger_transaction.json in the
+output folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "ledger_transaction", nil, processLedgerTransaction)
 	},

--- a/cmd/export_ledgers.go
+++ b/cmd/export_ledgers.go
@@ -16,7 +16,7 @@ var ledgersCmd = &cobra.Command{
 	Short: "Exports the ledger data over a specified range.",
 	Long: `Exports ledger data within the specified range. Ledgers are
 processed in batches of batch-size; each batch produces one file named
-{start}-{end}-ledgers.txt in the output folder.`,
+{start}-{end}-ledgers.json in the output folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "ledgers", new(transform.LedgerOutputParquet), processLedger)
 	},

--- a/cmd/export_ledgers.go
+++ b/cmd/export_ledgers.go
@@ -14,9 +14,9 @@ import (
 var ledgersCmd = &cobra.Command{
 	Use:   "export_ledgers",
 	Short: "Exports the ledger data over a specified range.",
-	Long: `Exports ledger data within the specified range. Ledgers are
-processed in batches of batch-size; each batch produces one file named
-{start}-{end}-ledgers.json in the output folder.`,
+Long: `Exports ledger data within the specified range. Ledgers are
+processed in batches of batch-size; each batch produces one newline-delimited
+JSON file named {start}-{end}-ledgers.json in the output folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "ledgers", new(transform.LedgerOutputParquet), processLedger)
 	},

--- a/cmd/export_operations.go
+++ b/cmd/export_operations.go
@@ -16,7 +16,7 @@ var operationsCmd = &cobra.Command{
 	Short: "Exports the operations data over a specified range.",
 	Long: `Exports the operations data over a specified range. Ledgers are
 processed in batches of batch-size; each batch produces one file named
-{start}-{end}-operations.txt in the output folder.`,
+{start}-{end}-operations.json in the output folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "operations", new(transform.OperationOutputParquet), processOperations)
 	},

--- a/cmd/export_operations.go
+++ b/cmd/export_operations.go
@@ -14,9 +14,9 @@ import (
 var operationsCmd = &cobra.Command{
 	Use:   "export_operations",
 	Short: "Exports the operations data over a specified range.",
-	Long: `Exports the operations data over a specified range. Ledgers are
-processed in batches of batch-size; each batch produces one file named
-{start}-{end}-operations.json in the output folder.`,
+Long: `Exports the operations data over a specified range. Ledgers are
+processed in batches of batch-size; each batch produces one newline-delimited
+JSON file named {start}-{end}-operations.json in the output folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "operations", new(transform.OperationOutputParquet), processOperations)
 	},

--- a/cmd/export_token_transfers.go
+++ b/cmd/export_token_transfers.go
@@ -15,7 +15,7 @@ var tokenTransfersCmd = &cobra.Command{
 	Short: "Exports the token transfer event data over a specified range.",
 	Long: `Exports the token transfer event data over a specified range.
 Ledgers are processed in batches of batch-size; each batch produces one file
-named {start}-{end}-token_transfer.txt in the output folder.`,
+named {start}-{end}-token_transfer.json in the output folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "token_transfer", nil, processTokenTransfers)
 	},

--- a/cmd/export_token_transfers.go
+++ b/cmd/export_token_transfers.go
@@ -13,9 +13,10 @@ import (
 var tokenTransfersCmd = &cobra.Command{
 	Use:   "export_token_transfer",
 	Short: "Exports the token transfer event data over a specified range.",
-	Long: `Exports the token transfer event data over a specified range.
-Ledgers are processed in batches of batch-size; each batch produces one file
-named {start}-{end}-token_transfer.json in the output folder.`,
+Long: `Exports the token transfer event data over a specified range.
+Ledgers are processed in batches of batch-size; each batch produces one
+newline-delimited JSON file named {start}-{end}-token_transfer.json in the
+output folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "token_transfer", nil, processTokenTransfers)
 	},

--- a/cmd/export_trades.go
+++ b/cmd/export_trades.go
@@ -16,9 +16,9 @@ import (
 var tradesCmd = &cobra.Command{
 	Use:   "export_trades",
 	Short: "Exports the trade data over a specified range.",
-	Long: `Exports trade data within the specified range. Ledgers are
-processed in batches of batch-size; each batch produces one file named
-{start}-{end}-trades.json in the output folder.`,
+Long: `Exports trade data within the specified range. Ledgers are processed in
+batches of batch-size; each batch produces one newline-delimited JSON file
+named {start}-{end}-trades.json in the output folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "trades", new(transform.TradeOutputParquet), processTrades)
 	},

--- a/cmd/export_trades.go
+++ b/cmd/export_trades.go
@@ -18,7 +18,7 @@ var tradesCmd = &cobra.Command{
 	Short: "Exports the trade data over a specified range.",
 	Long: `Exports trade data within the specified range. Ledgers are
 processed in batches of batch-size; each batch produces one file named
-{start}-{end}-trades.txt in the output folder.`,
+{start}-{end}-trades.json in the output folder.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "trades", new(transform.TradeOutputParquet), processTrades)
 	},

--- a/cmd/export_transactions.go
+++ b/cmd/export_transactions.go
@@ -16,7 +16,7 @@ var transactionsCmd = &cobra.Command{
 	Short: "Exports the transaction data over a specified range.",
 	Long: `Exports the transaction data over a specified range. Ledgers are
 processed in batches of batch-size. Each batch produces one file named
-{start}-{end}-transactions.txt (and .parquet when --write-parquet is set) in
+{start}-{end}-transactions.json (and .parquet when --write-parquet is set) in
 the output folder, which is uploaded before the next batch is processed.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "transactions", new(transform.TransactionOutputParquet), processTransactions)

--- a/cmd/export_transactions.go
+++ b/cmd/export_transactions.go
@@ -14,10 +14,11 @@ import (
 var transactionsCmd = &cobra.Command{
 	Use:   "export_transactions",
 	Short: "Exports the transaction data over a specified range.",
-	Long: `Exports the transaction data over a specified range. Ledgers are
-processed in batches of batch-size. Each batch produces one file named
-{start}-{end}-transactions.json (and .parquet when --write-parquet is set) in
-the output folder, which is uploaded before the next batch is processed.`,
+Long: `Exports the transaction data over a specified range. Ledgers are
+processed in batches of batch-size. Each batch produces one newline-delimited
+JSON file named {start}-{end}-transactions.json (and .parquet when
+--write-parquet is set) in the output folder, which is uploaded before the next
+batch is processed.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		runLedgerBatchExport(cmd, "transactions", new(transform.TransactionOutputParquet), processTransactions)
 	},

--- a/internal/utils/main.go
+++ b/internal/utils/main.go
@@ -249,7 +249,7 @@ func AddCommonFlags(flags *pflag.FlagSet) {
 // TODO: https://stellarorg.atlassian.net/browse/HUBBLE-386 Rename AddArchiveFlags to something more relevant
 func AddArchiveFlags(objectName string, flags *pflag.FlagSet) {
 	flags.Uint32P("start-ledger", "s", 2, "The ledger sequence number for the beginning of the export period. Defaults to genesis ledger")
-	flags.StringP("output", "o", "exported_"+objectName+".txt", "Filename of the output file")
+	flags.StringP("output", "o", "exported_"+objectName+".json", "Filename of the output file")
 	flags.String("parquet-output", "exported_"+objectName+".parquet", "Filename of the parquet output file")
 	flags.Int64P("limit", "l", -1, "Maximum number of "+objectName+" to export. If the limit is set to a negative number, all the objects in the provided range are exported")
 }

--- a/internal/utils/main.go
+++ b/internal/utils/main.go
@@ -234,7 +234,7 @@ func AddCommonFlags(flags *pflag.FlagSet) {
 	flags.Bool("strict-export", true, "If set, transform errors will be fatal.")
 	flags.Bool("testnet", false, "If set, will connect to Testnet instead of Mainnet.")
 	flags.Bool("futurenet", false, "If set, will connect to Futurenet instead of Mainnet.")
-	flags.StringToStringP("extra-fields", "u", map[string]string{}, "Additional fields to append to output jsons. Used for appending metadata")
+	flags.StringToStringP("extra-fields", "u", map[string]string{}, "Additional fields to append to output JSON rows. Used for appending metadata")
 	flags.Bool("captive-core", false, "(Deprecated; Will be removed in the Protocol 23 update) If set, run captive core to retrieve data. Otherwise use TxMeta file datastore.")
 	// TODO: This should be changed back to sdf-ledger-close-meta/ledgers when P23 is released and data lake is updated
 	flags.String("datastore-path", "sdf-ledger-close-meta/v1/ledgers", "Datastore bucket path to read txmeta files from.")
@@ -249,7 +249,7 @@ func AddCommonFlags(flags *pflag.FlagSet) {
 // TODO: https://stellarorg.atlassian.net/browse/HUBBLE-386 Rename AddArchiveFlags to something more relevant
 func AddArchiveFlags(objectName string, flags *pflag.FlagSet) {
 	flags.Uint32P("start-ledger", "s", 2, "The ledger sequence number for the beginning of the export period. Defaults to genesis ledger")
-	flags.StringP("output", "o", "exported_"+objectName+".json", "Filename of the output file")
+	flags.StringP("output", "o", "exported_"+objectName+".json", "Filename of the newline-delimited JSON output file")
 	flags.String("parquet-output", "exported_"+objectName+".parquet", "Filename of the parquet output file")
 	flags.Int64P("limit", "l", -1, "Maximum number of "+objectName+" to export. If the limit is set to a negative number, all the objects in the provided range are exported")
 }
@@ -260,7 +260,7 @@ func AddArchiveFlags(objectName string, flags *pflag.FlagSet) {
 // batches via input.StreamLedgerBatches.
 func AddLedgerBatchFlags(objectName string, flags *pflag.FlagSet, defaultFolder string) {
 	flags.Uint32P("start-ledger", "s", 2, "The ledger sequence number for the beginning of the export period. Defaults to genesis ledger")
-	flags.StringP("output", "o", defaultFolder, "Folder that will contain the "+objectName+" output files")
+	flags.StringP("output", "o", defaultFolder, "Folder that will contain the "+objectName+" newline-delimited JSON output files")
 	flags.String("parquet-output", defaultFolder, "Folder that will contain the "+objectName+" parquet output files")
 	flags.Uint32P("batch-size", "b", 64, "Number of ledgers to export per batch")
 }


### PR DESCRIPTION
## Summary
- change generated JSON-line batch export filenames from `.txt` to `.json`
- update the default archive export filename extension to `.json`
- align command help text and README examples with the JSON output extension
- add a regression test for batch export filename generation

Fixes #327.

## Testing
- `git diff --check`
- `rg -n "\{start\}-\{end\}.*\.txt|exported_(ledgers|transactions|operations|effects|assets|trades).*\.txt|export_diagnostic_events\.txt|exported_.*\.txt" cmd internal README.md --glob "!*test.go"`

`go test` was not run locally because Go is not installed in this environment.