### PR TITLE
Add DEVELOPING.md and CONTRIBUTING.md, trim README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,25 @@
 Thanks for taking the time to improve stellar-etl!
 
 The following is a set of guidelines for contributions and may change over
-time. Feel free to suggest improvements to this document in a pull request.We
+time. Feel free to suggest improvements to this document in a pull request. We
 want to make it as easy as possible to contribute changes that help the Stellar
 network grow and thrive. There are a few guidelines that we ask contributors to
 follow so that we can merge your changes quickly.
+
+Start with the [Stellar Contribution Guide](https://github.com/stellar/.github/blob/master/CONTRIBUTING.md),
+which applies to every Stellar project. For instructions on building, running,
+and testing the ETL, see [DEVELOPING.md](DEVELOPING.md).
+
+## Table of Contents
+
+- [Branches](#branches)
+- [Commit messages](#commit-messages)
+- [Pull requests](#pull-requests)
+- [Issues](#issues)
+- [Releases](#releases)
+- [Go style guide](#go-style-guide)
+- [Documentation](#documentation)
+- [Security](#security)
 
 ## Branches
 
@@ -19,3 +34,87 @@ a patch (to fix bugs). With that information, create your branch name like this:
 - `patch/<branch-name>`
 
 If branch is already made, just rename it _before creating the pull request_.
+
+The prefix is not just a convention: the release workflow reads it to decide
+which part of the version to increment when your pull request merges. See
+[Releases](#releases).
+
+## Commit messages
+
+- Use the present tense ("Add feature" not "Added feature").
+- Use the imperative mood ("Move cursor to..." not "Moves cursor to...").
+- Keep the subject line short and put context in the body.
+
+## Pull requests
+
+Open pull requests against `master`, or against the active `release-*` branch if
+the change belongs to a release already in flight.
+
+The [pull request template](.github/pull_request_template.md) asks you to fill
+in **What**, **Why**, and **Known limitations**. The "Why" matters most — include
+enough context that a reviewer who has not seen the issue can follow the change.
+
+- Keep scope narrow. Aim for something a reviewer can get through in about 20
+  minutes; break bigger work into a series of pull requests.
+- Do not mix refactoring with feature work. Refactoring pull requests touch far
+  more code and get reviewed in less detail, so keep them separate.
+- Add tests for the most critical parts of new functionality and fixes. If your
+  change alters an export's output, regenerate the golden files in `testdata/`
+  and call out the diff in the description.
+- Update the [README](README.md) or [DEVELOPING.md](DEVELOPING.md) when you add
+  a command, change a flag, or change how the repository is built or run.
+- Pull requests need to pass linting, the `internal` build, and the integration
+  tests, which enforce a 55% coverage floor.
+
+## Issues
+
+- Label issues with `bug` if they are clearly a bug, and `feature request` if
+  they are a feature request.
+- For a bug, include the command you ran, the flags, the network, and the
+  ledger range, along with the error output.
+
+## Releases
+
+Merging a pull request into `master` tags a new version and publishes a GitHub
+release automatically. The version bump comes from your **branch prefix**:
+
+| Branch prefix | Version bump | Use for                                         |
+| ------------- | ------------ | ----------------------------------------------- |
+| `major/`      | major        | Incompatible changes                            |
+| `minor/`      | minor        | New functionality, backward compatible          |
+| anything else | patch        | Backward-compatible bug fixes and documentation |
+
+Note that a branch with no recognized prefix still produces a patch release, so
+a breaking change on a mis-named branch gets an incorrect version. Rename the
+branch before opening the pull request.
+
+Merging to `master` also builds a Docker image tagged with the 9-character
+commit SHA and pushes it to Google Artifact Registry. Consumers such as
+[stellar-etl-airflow](https://github.com/stellar/stellar-etl-airflow) pin that
+image tag, so a change here is not live anywhere until the pin is bumped.
+
+## Go style guide
+
+- Format with `gofmt`, or preferably `goimports`. The pre-commit hooks run both.
+- Follow [Effective Go](https://go.dev/doc/effective_go) and
+  [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments).
+- Document exported package elements: vars, consts, funcs, types.
+- Log errors through `cmdLogger.LogError` rather than calling `Error` or `Fatal`
+  directly, so the `--strict-export` flag is honored. See
+  [Logging](DEVELOPING.md#logging).
+- Tests are better than no tests.
+
+## Documentation
+
+- Command usage, flags, and output schemas belong in the [README](README.md).
+- Build, run, test, and debug instructions belong in
+  [DEVELOPING.md](DEVELOPING.md).
+- Contribution process, style, and release mechanics belong here.
+- Prose in Markdown files is formatted by `prettier` through pre-commit, so run
+  the hooks before pushing.
+
+## Security
+
+Please do not open a public issue for a suspected vulnerability. Follow the
+[Stellar security policy](https://github.com/stellar/.github/blob/master/SECURITY.md)
+instead.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,282 @@
+# Developing
+
+Welcome to stellar-etl. These instructions cover building, running, and testing
+the ETL locally.
+
+For what stellar-etl is and a reference for every export command, read the
+[README](README.md). If you plan to open a pull request, also read the
+[contributing guidelines](CONTRIBUTING.md).
+
+## Table of Contents
+
+- [Requirements](#requirements)
+- [Get the code](#get-the-code)
+- [Building locally](#building-locally)
+- [Running locally](#running-locally)
+- [Dependencies](#dependencies)
+- [Running tests](#running-tests)
+- [Linting](#linting)
+- [Logging](#logging)
+- [Adding a new command](#adding-a-new-command)
+- [Tips and notes](#tips-and-notes)
+
+## Requirements
+
+To check out, build, and run stellar-etl you need:
+
+- [Git](https://git-scm.com/downloads)
+- [Go](https://golang.org/dl) at the version pinned in [go.mod](go.mod)
+- [Docker](https://www.docker.com/get-started) and Docker Compose, to build the
+  image and to run the integration tests
+
+Some workflows need extra tooling:
+
+- The [gcloud CLI](https://cloud.google.com/sdk/docs/install), for reading
+  TxMeta files from a GCS datastore and for running the integration tests.
+- [Stellar Core](https://github.com/stellar/stellar-core/blob/master/INSTALL.md)
+  v20.0.0 or later, only if you pass `--captive-core` instead of reading from a
+  datastore.
+
+Make sure your Go bin directory is on your `PATH`:
+
+```sh
+export PATH=$PATH:$(go env GOPATH)/bin
+```
+
+## Get the code
+
+Check the code out anywhere; a `GOPATH` is not required.
+
+```sh
+git clone https://github.com/stellar/stellar-etl
+cd stellar-etl
+```
+
+## Building locally
+
+Build the binary:
+
+```sh
+go build
+```
+
+Build the Docker image. The `docker-build` target tags the image with the
+9-character short SHA of `HEAD` as well as `latest`:
+
+```sh
+make docker-build
+```
+
+Override the tag with `ETLHASH` if you need a specific one:
+
+```sh
+ETLHASH=stellar/stellar-etl:my-tag make docker-build
+```
+
+## Running locally
+
+Run a command straight from the local build:
+
+```sh
+./stellar-etl export_ledgers --start-ledger 1000 --end-ledger 500000 \
+  --output exported_ledgers.txt
+```
+
+Or run it inside the image you just built:
+
+```sh
+docker run --platform linux/amd64 -it stellar/stellar-etl:latest /bin/bash
+root@71890b878fca:/etl/data# stellar-etl export_ledgers --start-ledger 1000 \
+  --end-ledger 500000 --output exported_ledgers.txt
+```
+
+### GCP credentials
+
+The export commands read compressed `LedgerCloseMetaBatch` XDR files from a GCS
+datastore, so they need application default credentials:
+
+```sh
+gcloud auth login
+gcloud config set project <your gcp project>
+gcloud auth application-default login
+```
+
+To pass those credentials into a container, mount them and point
+`GOOGLE_APPLICATION_CREDENTIALS` at the mount:
+
+```sh
+docker run --platform linux/amd64 -it \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/.config/gcp/credentials.json \
+  -v "$HOME/.config/gcloud/application_default_credentials.json":/.config/gcp/credentials.json:ro \
+  stellar/stellar-etl:latest /bin/bash
+```
+
+## Dependencies
+
+stellar-etl uses [Go modules](https://go.dev/ref/mod). Add a dependency by
+importing it and running any Go command, or pin a version explicitly:
+
+```sh
+go get <importpath>@<version>
+```
+
+Run `go mod tidy` before opening a pull request so `go.mod` and `go.sum` stay
+tidy.
+
+> _*Note:*_ The `internal` directory builds separately in CI
+> (`cd internal && go build ./...`), so a dependency change that only compiles
+> from the repository root can still fail the `internal` job.
+
+## Running tests
+
+### Unit tests
+
+Unit tests cover the transform layer and the helpers in `internal`, and need no
+credentials:
+
+```sh
+# All transform tests
+go test -v -cover ./internal/transform
+
+# A single test
+go test -v -run ^TestTransformAsset$ ./internal/transform
+```
+
+### Integration tests
+
+The tests in `cmd` run each CLI command end to end against real TxMeta files in
+GCS, so they run inside Docker Compose and need GCP credentials:
+
+```sh
+# All integration tests
+make int-test
+
+# All integration tests, regenerating golden files
+make int-test-update
+```
+
+Both targets wrap `docker-compose`, mounting your application default
+credentials and the `testdata` directory into the container:
+
+```sh
+docker-compose build
+docker-compose run \
+  -v $(HOME)/.config/gcloud/application_default_credentials.json:/usr/credential.json:ro \
+  -v $(PWD)/testdata:/usr/src/etl/testdata \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/usr/credential.json \
+  integration-tests \
+  go test -v ./cmd -timeout 30m
+```
+
+Run a single integration test by passing `-run` through to `go test`:
+
+```sh
+docker-compose run \
+  -v $(HOME)/.config/gcloud/application_default_credentials.json:/usr/credential.json:ro \
+  -v $(PWD)/testdata:/usr/src/etl/testdata \
+  -e GOOGLE_APPLICATION_CREDENTIALS=/usr/credential.json \
+  integration-tests \
+  go test -v -run ^TestExportAssets$ ./cmd -timeout 30m
+```
+
+### Golden files
+
+The integration tests compare command output against golden files in
+`testdata/`. When you intentionally change an export's output, regenerate them
+with `make int-test-update` (or `-args -update=true`) and **review the diff** —
+the golden files are the reference for what lands in BigQuery, so an unexpected
+change there is a real finding, not noise.
+
+> _*Note:*_ Golden files for commands that legitimately return no rows are a
+> single newline, and `.pre-commit-config.yaml` excludes them from the
+> `end-of-file-fixer` and `trailing-whitespace` hooks.
+
+### Coverage
+
+CI runs `./cmd` and `./internal/transform` together and fails if total coverage
+drops below **55%**.
+
+## Linting
+
+Install the hooks once, then let them run on every commit:
+
+```sh
+pre-commit install
+```
+
+Run them over the whole repository the way CI does:
+
+```sh
+make lint
+```
+
+This runs [golangci-lint](https://golangci-lint.run/) (`gofmt`, `goimports`,
+`importas`, `misspell`) plus `prettier` over JSON, YAML, and Markdown files and
+a handful of hygiene checks. CI only lints the files a pull request touches.
+
+## Logging
+
+Commands log through `utils.EtlLogger`, a thin wrapper around
+[`support/log`](https://github.com/stellar/go-stellar-sdk/tree/master/support/log)
+declared in `internal/utils/logger.go`. `cmd/root.go` creates the single
+`cmdLogger` that every command uses.
+
+The important behavior is `LogError`, which branches on the logger's
+`StrictExport` field:
+
+- `StrictExport = true` (the `--strict-export` flag, which
+  `utils.AddCommonFlags` defaults to `true`) → `Fatal`: the command logs the
+  error and exits non-zero.
+- `StrictExport = false` → `Error`: the command logs the error, **keeps going,
+  and still exits 0**.
+
+So a run with `--strict-export=false` can drop rows and still look green. When
+you add a new code path, use `cmdLogger.LogError` rather than `Error` or
+`Fatal` directly so it honors that flag, and check logs for `level=error` when a
+run's row counts look low.
+
+## Adding a new command
+
+To add a new export, add these files:
+
+- `cmd/export_new_data_structure.go`
+  - Generate the skeleton with `cobra add {command}`.
+  - This file parses flags, creates output files, gets the transformed data from
+    the input package, and exports it.
+- `cmd/export_new_data_structure_test.go`
+  - `runCLI` does most of the heavy lifting; the test supplies the command
+    arguments and the expected output.
+  - Test data goes in `testdata/new_data_structure/`.
+- `internal/input/new_data_structure.go`
+  - Extracts the new data structure from wherever it lives: the history
+    archives, the bucket list, a captive core instance, or a datastore.
+  - Captive core work needs to happen in the background: one set of methods
+    exports batches of data onto a channel, another reads from the channel and
+    transforms the data for export.
+- `internal/transform/new_data_structure.go`
+  - Transforms the extracted data into a shape suitable for BigQuery. The struct
+    definition belongs in `internal/transform/schema.go`.
+
+A good number of common helpers already exist in `internal/utils`.
+
+> _*Note:*_ A struct in `schema.go` is not enough on its own. A new export also
+> needs its Parquet counterpart in `internal/transform/schema_parquet.go` and a
+> conversion in `internal/transform/parquet_converter.go`, plus a matching
+> schema JSON in
+> [stellar-etl-airflow](https://github.com/stellar/stellar-etl-airflow) before
+> the data can land in BigQuery.
+
+## Tips and notes
+
+- Every command accepts `-h`, which prints its usage and flags.
+- Commands read from mainnet by default; `--testnet` and `--futurenet` switch
+  networks. A command can only read from one network per run, and setting both
+  flags falls back to testnet.
+- Prefer processing large ledger ranges over many small ones. With
+  `--captive-core`, each run pays the Stellar Core catch-up cost, which grows as
+  the network does.
+- Recommended pod resources for running captive core in Kubernetes:
+  `{cpu: 3.5, memory: 20Gi, ephemeral-storage: 12Gi}`.
+- `--batch-size` for `export_ledger_entry_changes` defaults to 64 ledgers, which
+  lines up with the network's checkpoint ledgers. Keep batch sizes as multiples
+  of 64.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,19 @@
 
 The Stellar-ETL is a data pipeline that allows users to extract data from the history of the Stellar network.
 
+## **Documentation**
+
+| Document                           | Contents                                                                 |
+| ---------------------------------- | ------------------------------------------------------------------------ |
+| This README                        | Installing the ETL and a reference for every command it exposes          |
+| [DEVELOPING.md](DEVELOPING.md)     | Building, running, and testing the ETL locally, and adding a new command |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Branch naming, pull request etiquette, release mechanics, and Go style   |
+
+For background on the Stellar network and the data this pipeline extracts, see
+the [Stellar developer documentation](https://developers.stellar.org/). For the
+BigQuery datasets built on top of this ETL, see
+[Hubble](https://developers.stellar.org/docs/data/analytics/hubble).
+
 ## **Table of Contents**
 
 - [Install](#install)
@@ -21,8 +34,6 @@ The Stellar-ETL is a data pipeline that allows users to extract data from the hi
   - [Utility Commands](#utility-commands)
     - [get_ledger_range_from_times](#get_ledger_range_from_times)
 - [Schemas](#schemas)
-- [Extensions](#extensions)
-  - [Adding New Commands](#adding-new-commands)
 
 <br>
 
@@ -38,87 +49,17 @@ The Stellar-ETL is a data pipeline that allows users to extract data from the hi
 
 ## **Manual Installation**
 
-1. Install Golang v1.23.0 or later: https://golang.org/dl/
+1. Install Golang at the version pinned in [go.mod](go.mod) or later: https://golang.org/dl/
 2. Ensure that your Go bin has been added to the PATH env variable: `export PATH=$PATH:$(go env GOPATH)/bin`
 3. If using captive-core, download and install Stellar-Core v20.0.0 or later: https://github.com/stellar/stellar-core/blob/master/INSTALL.md
 4. Run `go install github.com/stellar/stellar-etl/v2@latest` to install the ETL
 5. Run export commands to export information about the legder
 
-## **Manual build for local development**
+## **Building from source**
 
-1. Clone this repo `git clone https://github.com/stellar/stellar-etl`
-2. Build stellar-etl with `go build`
-3. Build the docker image locally with `make docker-build`
-4. Run the docker container in interactive mode to run export commands.
-
-```sh
-$ docker run --platform linux/amd64 -it stellar/stellar-etl:latest /bin/bash
-```
-
-5. Run export commands to export information about the legder
-   Example command to export ledger data
-
-```sh
-root@71890b878fca:/etl/data# stellar-etl export_ledgers --start-ledger 1000 --end-ledger 500000 --output exported_ledgers.txt
-```
-
-> _*Note:*_ If using the GCS datastore, you can run the following to set GCP credentials to use in your shell
-
-```
-gcloud auth login
-gcloud config set project dev-hubble
-gcloud auth application-default login
-```
-
-Add following to docker run command to pass gcloud credentials to docker container
-
-```
--e GOOGLE_APPLICATION_CREDENTIALS=/.config/gcp/credentials.json -v "$HOME/.config/gcloud/application_default_credentials.json":/.config/gcp/credentials.json:ro
-```
-
-> _*Note:*_ Instructions for installing gcloud can be found [here](https://cloud.google.com/sdk/docs/install-sdk)
+To build, run, and test the ETL locally, see [DEVELOPING.md](DEVELOPING.md).
 
 <br>
-
-## **Running Tests**
-
-### Unit tests
-
-```sh
-# Running all unit tests
-go test -v -cover ./internal/transform
-
-# Running an individual test
-go test -v -run ^TestTransformAsset$ ./internal/transform
-```
-
-### Integration tests
-
-```sh
-# Running all integration tests
-make int-test
-
-# Running all integration tests and update golden files
-make int-test-update
-
-# Above essentially runs following:
-docker-compose build
-docker-compose run \
--v $(HOME)/.config/gcloud/application_default_credentials.json:/usr/credential.json:ro \
--v $(PWD)/testdata:/usr/src/etl/testdata \
--e GOOGLE_APPLICATION_CREDENTIALS=/usr/credential.json \
-integration-tests \
-go test -v ./cmd -timeout 30m -args -update=true
-
-# Running an individual test
-docker-compose build
-docker-compose run \
--v $(HOME)/.config/gcloud/application_default_credentials.json:/usr/credential.json:ro \
--v $(PWD)/testdata:/usr/src/etl/testdata \
--e GOOGLE_APPLICATION_CREDENTIALS=/usr/credential.json \
-integration-tests \
-go test -v -run ^TestExportAssets$ ./cmd -timeout 30m -args -update=true
-```
 
 ---
 
@@ -148,9 +89,9 @@ Commands have the option to read from testnet with the `--testnet` flag, from fu
 
 ## **Export Commands**
 
-These commands export information using the [Ledger Exporter](https://github.com/stellar/go/blob/master/exp/services/ledgerexporter/README.md) output files within a specified datastore (currently [datastore](https://github.com/stellar/go/tree/master/support/datastore) only supports GCS). This allows users to provide a start and end ledger range. The commands in this category export a list of everything that occurred within the provided range. All of the ranges are inclusive.
+These commands export information using the [Galexie](https://developers.stellar.org/docs/data/indexers/build-your-own/galexie) output files within a specified datastore (currently [datastore](https://github.com/stellar/go-stellar-sdk/tree/master/support/datastore) only supports GCS). This allows users to provide a start and end ledger range. The commands in this category export a list of everything that occurred within the provided range. All of the ranges are inclusive.
 
-> _*NOTE:*_ The datastore must contain the expected compressed LedgerCloseMetaBatch XDR binary files as exported from [Ledger Exporter](https://github.com/stellar/go/blob/master/exp/services/ledgerexporter/README.md#exported-files).
+> _*NOTE:*_ The datastore must contain the expected compressed LedgerCloseMetaBatch XDR binary files as exported from [Galexie](https://developers.stellar.org/docs/data/indexers/build-your-own/galexie).
 
 #### Common Flags
 
@@ -346,23 +287,5 @@ See https://github.com/stellar/stellar-etl/blob/master/internal/transform/schema
 
 # Extensions
 
-This section covers some possible extensions or further work that can be done.
-
-## **Adding New Commands**
-
-In general, in order to add new commands, you need to add these files:
-
-- `export_new_data_structure.go` in the `cmd` folder
-  - This file can be generated with cobra by calling: `cobra add {command}`
-  - This file will parse flags, create output files, get the transformed data from the input package, and then export the data.
-- `export_new_data_structure_test.go` in the `cmd` folder
-  - This file will contain some tests for the newly added command. The `runCLI` function does most of the heavy lifting. All the tests need is the command arguments to test and the desired output.
-  - Test data should be stored in the `testdata/new_data_structure` folder
-- `new_data_structure.go` in the `internal/input` folder
-  - This file will contain the methods needed to extract the new data structure from wherever it is located. This may be the history archives, the bucket list, a captive core instance, or a datastore.
-  - If working with captive core, the methods need to work in the background. There should be methods that export batches of data and send them to a channel. There should be other methods that read from the channel and transform the data so it can be exported.
-- `new_data_structure.go` in the `internal/transform` folder
-  - This file will contain the methods needed to transform the extracted data into a form that is suitable for BigQuery.
-  - The struct definition for the transformed object should be stored in `schemas.go` in the `internal/transform` folder.
-
-A good number of common methods are already written and stored in the `util` package.
+To add a new export command, see
+[Adding a new command](DEVELOPING.md#adding-a-new-command).


### PR DESCRIPTION
### What

Splits the README into three documents, following the structure requested in
stellar/hubble#412:

- **`DEVELOPING.md`** (new) — requirements, getting the code, building locally,
  running locally, dependencies, running tests, linting, logging, adding a new
  command, and tips.
- **`CONTRIBUTING.md`** (expanded from a branch-naming stub) — branches, commit
  messages, pull request etiquette, issues, release mechanics, Go style guide,
  documentation, and security.
- **`README.md`** (trimmed) — keeps the install steps and the full command
  reference, and links out to the other two from a Documentation table at the
  top.

### Why

Everything currently lives in the README, which mixes "how do I use the CLI"
with "how do I build and test it." A new contributor reads 370 lines to find
the four they need. Splitting by audience means each reader lands on the right
file, which is what stellar/go does and what the issue asks for.

Three things were fixed rather than copied forward while moving content:

- The README pinned Go v1.23.0; `go.mod` says 1.25.3. It now points at
  `go.mod` so it cannot drift again.
- Two links pointed at `stellar/go/exp/services/ledgerexporter`, which 404s —
  `stellar/go` is deprecated and the ledger exporter is now Galexie. They point
  at the Galexie docs, and the `support/datastore` link points at
  `go-stellar-sdk`.
- `DEVELOPING.md` documents the `--strict-export` / `LogError` behavior. With
  `--strict-export=false` a run logs a transform error, keeps going, and still
  exits 0, so it can silently drop rows and look green. That is worth writing
  down for anyone adding a code path.

### Known limitations

Docs only — no behavior change.

stellar/hubble#412 also asks for these files in `stellar-etl-airflow` and
`stellar-dbt`, which are internal repos, so they are out of scope here. The
companion public-repo PR is stellar/stellar-dbt-public (same branch name).
