### PR TITLE
Update PR and Issue templates

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -89,3 +89,17 @@ Four files are required:
 - Prefer small and focused changes over large rewrites
 - Keep PRs scoped to only the request
 - Never commit secrets, API keys, or credentials
+
+## Pull requests
+
+Write the PR body as a cover note for a reviewer, not a changelog or a file-by-file summary.
+Use the smallest shape that makes the change easier to review:
+
+- Small or obvious change: one paragraph, no headings.
+- Transform, input, or command change: what changed and its effect. Add root cause or the non-obvious approach only when the diff does not already show it.
+- Output schema change (a new, renamed, retyped, or dropped field in `internal/transform/schema.go`): name the field and the exported table, and say whether a re-export or backfill is needed.
+- Cross-repo change: an output schema change also needs a schema JSON in stellar-etl-airflow and a source YAML plus staging model in the dbt repos. Link the companion PRs, or say in Data impact that they do not exist yet.
+
+IMPORTANT: do not add Summary, Changes, Test Plan, or Files Changed sections. Do not paste commands, test output, CI logs, commit logs, or file lists. No emoji. No step-by-step narration of what you did.
+
+Fill the headings in `.github/pull_request_template.md` and no others. Treat the HTML comments in that template as instructions: follow them, then delete them from the final body. Leave the footer checkboxes unticked; they are the author's to tick.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: An export command produces wrong, missing, or malformed data
+labels: ["bug"]
+body:
+  - type: input
+    id: affected
+    attributes:
+      label: Affected export command or table
+      description: The stellar-etl command, or the BigQuery table it lands in.
+      placeholder: export_operations, or crypto_stellar.history_operations
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-actual
+    attributes:
+      label: What you expected vs. what you got
+      placeholder: |
+        Expected: every operation row has a non-null transaction_id
+        Actual: ~3% of rows in ledger range 56100000-56110000 have transaction_id = 0
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Command or query that shows it
+      description: The stellar-etl invocation with its ledger range, or the query against the loaded table.
+      render: shell
+    validations:
+      required: false
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      options:
+        - Blocking a stakeholder
+        - Wrong data in production
+        - Internal only
+        - Cosmetic
+    validations:
+      required: true
+
+  - type: input
+    id: started
+    attributes:
+      label: When it started
+      description: A ledger range, a date, or a release, if you know it.
+      placeholder: first seen after the Protocol 23 upgrade
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: A new export, a new field, a change to an existing command, or tooling work
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind
+      options:
+        - New export command
+        - New or changed output field
+        - Change to an existing command
+        - Tooling or CI
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve
+      description: The question someone cannot answer today, or the failure this would have caught.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like to see
+      description: The field, type, and source XDR path if you know them. A rough shape is fine.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: downstream
+    attributes:
+      label: Downstream work this implies
+      description: An output schema change is never just this repo. Tick what you think is needed.
+      options:
+        - label: Schema JSON in stellar-etl-airflow
+        - label: Source YAML and staging model in stellar-dbt-public or stellar-dbt
+        - label: Backfill or re-export of historical data

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,36 +1,17 @@
-<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
-template and use a short description, but in your description aim to include both what the
-change is, and why it is being made, with enough context for anyone to understand. -->
+## What & why
 
-<details>
-  <summary>PR Checklist</summary>
+## Data impact
 
-### PR Structure
+<!-- Exported tables and columns affected. Does stellar-etl-airflow need a schema JSON
+     change, and the dbt source YAML or staging model an update? Is a re-export or
+     backfill needed? "None" is a valid answer. -->
 
-- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
-- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
-      otherwise).
-- [ ] This PR's title starts with the jira ticket associated with the PR.
+## What feedback do you want
 
-### Thoroughness
+<!-- e.g. "check the XDR handling", "sanity-check the new column's type", "rubber stamp" -->
 
-- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
-- [ ] I've updated the README with the added features, breaking changes, new instructions on how to use the repository. I updated the description of the fuction with the changes that were made.
+---
 
-### Release planning
-
-- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
-    [semver](https://semver.org/), and I've changed the name of the BRANCH to major/_ , minor/_ or patch/\* .
-</details>
-
-### What
-
-[TODO: Short statement about what is changing.]
-
-### Why
-
-[TODO: Why this change is being made. Include any context required to understand the why.]
-
-### Known limitations
-
-[TODO or N/A]
+- [ ] I reviewed the diff myself and ran unit and integration tests.
+- [ ] Golden files regenerated, or N/A.
+- [ ] Branch is named `major/*`, `minor/*`, or `patch/*` (release-drafter reads it).


### PR DESCRIPTION
## What & why

Claude writes bloated PR bodies in these repos: Summary / Changes / Test Plan headings, pasted output, file-by-file lists. The fix is structural rather than adverbial, because GitHub documents style instructions ("be concise", "answer with a certain level of detail") as among the least reliable custom instructions you can give a model. This works three layers at once:

- **A thin PR template** with nothing left to pad: three headings and three checkboxes.
- **A size ladder and an explicit deny-list in `.claude/CLAUDE.md`**, the layer that actually changes behavior. Claude Code reads CLAUDE.md every session and does not reliably read `.github/pull_request_template.md`.
- **YAML issue forms**, the only server-side enforcement GitHub offers. There is no `validations: required` equivalent for PRs.

`What feedback do you want` is the one genuinely new heading. MSR 2026 (80k PRs, 156 projects) found requesting specific feedback is the single strongest predictor of merge, present in 16% of PRs, and ranked *least* important by the developers it surveyed. Nobody adds it voluntarily, so it goes in the skeleton.

Mirrors stellar/stellar-dbt#1146. The CLAUDE.md ladder is tailored per repo; here it names the real cross-repo trap: an output schema change in `internal/transform/schema.go` also needs a schema JSON in stellar-etl-airflow and a source YAML plus staging model in the dbt repos. The feature form makes that a checkbox list so a requester says up front what the change implies.

Issue forms replace the `stellar/.github` fallback, which asks for `stellar version` output and links to Stack Exchange.

## Data impact

None. Templates, agent instructions, and issue forms only. No exports change.

## What feedback do you want

Whether dropping five checklist items loses anything you rely on: jira-ticket titles (dead, no recent PR uses one), "adds tests", "narrow scope", "no mixed refactoring", and "updated the README" (all now in the CLAUDE.md rules). Also whether the footer's "ran unit and integration tests" is the right bar, given `make int-test` needs Docker and GCP credentials.

No `config.yml` here, deliberately: this repo is public, so it keeps the org's Discord and Stack Exchange contact links.

---

- [ ] I reviewed the diff myself and ran unit and integration tests.
- [ ] Golden files regenerated, or N/A.
- [ ] Branch is named `major/*`, `minor/*`, or `patch/*` (release-drafter reads it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
